### PR TITLE
fix: cleaner python json snippets

### DIFF
--- a/src/targets/python/helpers.js
+++ b/src/targets/python/helpers.js
@@ -1,0 +1,79 @@
+'use strict'
+
+var util = require('util')
+
+/**
+ * Create an string of given length filled with blank spaces
+ *
+ * @param {number} length Length of the array to return
+ * @return {string}
+ */
+function buildString (length, str) {
+  return Array.apply(null, new Array(length)).map(String.prototype.valueOf, str).join('')
+}
+
+/**
+ * Create a string corresponding to a Dictionary or Array literal representation with pretty option
+ * and indentation.
+ */
+function concatValues (concatType, values, pretty, indentation, indentLevel) {
+  var currentIndent = buildString(indentLevel, indentation)
+  var closingBraceIndent = buildString(indentLevel - 1, indentation)
+  var join = pretty ? ',\n' + currentIndent : ', '
+  var openingBrace = concatType === 'object' ? '{' : '['
+  var closingBrace = concatType === 'object' ? '}' : ']'
+
+  if (pretty) {
+    return openingBrace + '\n' + currentIndent + values.join(join) + '\n' + closingBraceIndent + closingBrace
+  } else {
+    return openingBrace + values.join(join) + closingBrace
+  }
+}
+
+module.exports = {
+  /**
+   * Create a valid Python string of a literal value according to its type.
+   *
+   * @param {*} value Any JavaScript literal
+   * @param {Object} opts Target options
+   * @return {string}
+   */
+  literalRepresentation: function (value, opts, indentLevel) {
+    indentLevel = indentLevel === undefined ? 1 : indentLevel + 1
+
+    switch (Object.prototype.toString.call(value)) {
+      case '[object Number]':
+        return value
+
+      case '[object Array]':
+        var pretty = false
+        var valuesRepresentation = value.map(function (v) {
+          // Switch to prettify if the value is a dictionary with multiple keys
+          if (Object.prototype.toString.call(v) === '[object Object]') {
+            pretty = Object.keys(v).length > 1
+          }
+          return this.literalRepresentation(v, opts, indentLevel)
+        }.bind(this))
+        return concatValues('array', valuesRepresentation, pretty, opts.indent, indentLevel)
+
+      case '[object Object]':
+        var keyValuePairs = []
+        for (var k in value) {
+          keyValuePairs.push(util.format('"%s": %s', k, this.literalRepresentation(value[k], opts, indentLevel)))
+        }
+        return concatValues('object', keyValuePairs, opts.pretty && keyValuePairs.length > 1, opts.indent, indentLevel)
+
+      case '[object Null]':
+        return 'None'
+
+      case '[object Boolean]':
+        return value ? 'True' : 'False'
+
+      default:
+        if (value === null || value === undefined) {
+          return ''
+        }
+        return '"' + value.toString().replace(/"/g, '\\"') + '"'
+    }
+  }
+}

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -47,7 +47,7 @@ module.exports = function (source, options) {
 
   if (headerCount === 1) {
     for (header in headers) {
-      code.push('headers = {\'%s\': \'%s\'}', header, headers[header])
+      code.push('headers = {"%s": "%s"}', header, headers[header])
           .blank()
     }
   } else if (headerCount > 1) {
@@ -57,13 +57,13 @@ module.exports = function (source, options) {
 
     for (header in headers) {
       if (count++ !== headerCount) {
-        code.push(1, '\'%s\': "%s",', header, headers[header])
+        code.push(1, '"%s": "%s",', header, headers[header])
       } else {
-        code.push(1, '\'%s\': "%s"', header, headers[header])
+        code.push(1, '"%s": "%s"', header, headers[header])
       }
     }
 
-    code.push(1, '}')
+    code.push('}')
         .blank()
   }
 

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -12,8 +12,14 @@
 
 var util = require('util')
 var CodeBuilder = require('../../helpers/code-builder')
+var helpers = require('./helpers')
 
 module.exports = function (source, options) {
+  var opts = Object.assign({
+    indent: '    ',
+    pretty: true
+  }, options)
+
   // Start snippet
   var code = new CodeBuilder('    ')
 
@@ -34,10 +40,23 @@ module.exports = function (source, options) {
   }
 
   // Construct payload
-  var payload = JSON.stringify(source.postData.text)
+  let hasPayload = false
+  let jsonPayload = false
+  switch (source.postData.mimeType) {
+    case 'application/json':
+      if (source.postData.jsonObj) {
+        code.push('payload = %s', helpers.literalRepresentation(source.postData.jsonObj, opts))
+        jsonPayload = true
+        hasPayload = true
+      }
+      break
 
-  if (payload) {
-    code.push('payload = %s', payload)
+    default:
+      var payload = JSON.stringify(source.postData.text)
+      if (payload) {
+        code.push('payload = %s', payload)
+        hasPayload = true
+      }
   }
 
   // Construct headers
@@ -71,8 +90,12 @@ module.exports = function (source, options) {
   var method = source.method
   var request = util.format('response = requests.request("%s", url', method)
 
-  if (payload) {
-    request += ', data=payload'
+  if (hasPayload) {
+    if (jsonPayload) {
+      request += ', json=payload'
+    } else {
+      request += ', data=payload'
+    }
   }
 
   if (headerCount > 0) {
@@ -100,5 +123,3 @@ module.exports.info = {
   link: 'http://docs.python-requests.org/en/latest/api/#requests.request',
   description: 'Requests HTTP library'
 }
-
-// response = requests.request("POST", url, data=payload, headers=headers, params=querystring)

--- a/test/fixtures/output/python/requests/application-form-encoded.py
+++ b/test/fixtures/output/python/requests/application-form-encoded.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "foo=bar&hello=world"
-headers = {'content-type': 'application/x-www-form-urlencoded'}
+headers = {"content-type": "application/x-www-form-urlencoded"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/application-json.py
+++ b/test/fixtures/output/python/requests/application-json.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"
-headers = {'content-type': 'application/json'}
+headers = {"content-type": "application/json"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/application-json.py
+++ b/test/fixtures/output/python/requests/application-json.py
@@ -2,9 +2,16 @@ import requests
 
 url = "http://mockbin.com/har"
 
-payload = "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"
+payload = {
+    "number": 1,
+    "string": "f\"oo",
+    "arr": [1, 2, 3],
+    "nested": {"a": "b"},
+    "arr_mix": [1, "a", {"arr_mix_nested": {}}],
+    "boolean": False
+}
 headers = {"content-type": "application/json"}
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.request("POST", url, json=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/cookies.py
+++ b/test/fixtures/output/python/requests/cookies.py
@@ -2,7 +2,7 @@ import requests
 
 url = "http://mockbin.com/har"
 
-headers = {'cookie': 'foo=bar; bar=baz'}
+headers = {"cookie": "foo=bar; bar=baz"}
 
 response = requests.request("POST", url, headers=headers)
 

--- a/test/fixtures/output/python/requests/full.py
+++ b/test/fixtures/output/python/requests/full.py
@@ -6,10 +6,10 @@ querystring = {"foo":["bar","baz"],"baz":"abc","key":"value"}
 
 payload = "foo=bar"
 headers = {
-    'cookie': "foo=bar; bar=baz",
-    'accept': "application/json",
-    'content-type': "application/x-www-form-urlencoded"
-    }
+    "cookie": "foo=bar; bar=baz",
+    "accept": "application/json",
+    "content-type": "application/x-www-form-urlencoded"
+}
 
 response = requests.request("POST", url, data=payload, headers=headers, params=querystring)
 

--- a/test/fixtures/output/python/requests/headers.py
+++ b/test/fixtures/output/python/requests/headers.py
@@ -3,9 +3,9 @@ import requests
 url = "http://mockbin.com/har"
 
 headers = {
-    'accept': "application/json",
-    'x-foo': "Bar"
-    }
+    "accept": "application/json",
+    "x-foo": "Bar"
+}
 
 response = requests.request("GET", url, headers=headers)
 

--- a/test/fixtures/output/python/requests/jsonObj-multiline.py
+++ b/test/fixtures/output/python/requests/jsonObj-multiline.py
@@ -2,9 +2,9 @@ import requests
 
 url = "http://mockbin.com/har"
 
-payload = "{\n  \"foo\": \"bar\"\n}"
+payload = {"foo": "bar"}
 headers = {"content-type": "application/json"}
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.request("POST", url, json=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/jsonObj-multiline.py
+++ b/test/fixtures/output/python/requests/jsonObj-multiline.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "{\n  \"foo\": \"bar\"\n}"
-headers = {'content-type': 'application/json'}
+headers = {"content-type": "application/json"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/jsonObj-null-value.py
+++ b/test/fixtures/output/python/requests/jsonObj-null-value.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "{\"foo\":null}"
-headers = {'content-type': 'application/json'}
+headers = {"content-type": "application/json"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/jsonObj-null-value.py
+++ b/test/fixtures/output/python/requests/jsonObj-null-value.py
@@ -2,9 +2,9 @@ import requests
 
 url = "http://mockbin.com/har"
 
-payload = "{\"foo\":null}"
+payload = {"foo": None}
 headers = {"content-type": "application/json"}
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.request("POST", url, json=payload, headers=headers)
 
 print(response.text)

--- a/test/fixtures/output/python/requests/multipart-data.py
+++ b/test/fixtures/output/python/requests/multipart-data.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\nHello World\r\n-----011000010111000001101001--\r\n"
-headers = {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+headers = {"content-type": "multipart/form-data; boundary=---011000010111000001101001"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/multipart-file.py
+++ b/test/fixtures/output/python/requests/multipart-file.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"; filename=\"hello.txt\"\r\nContent-Type: text/plain\r\n\r\n\r\n-----011000010111000001101001--\r\n"
-headers = {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+headers = {"content-type": "multipart/form-data; boundary=---011000010111000001101001"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/multipart-form-data.py
+++ b/test/fixtures/output/python/requests/multipart-form-data.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n"
-headers = {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+headers = {"content-type": "multipart/form-data; boundary=---011000010111000001101001"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 

--- a/test/fixtures/output/python/requests/text-plain.py
+++ b/test/fixtures/output/python/requests/text-plain.py
@@ -3,7 +3,7 @@ import requests
 url = "http://mockbin.com/har"
 
 payload = "Hello World"
-headers = {'content-type': 'text/plain'}
+headers = {"content-type": "text/plain"}
 
 response = requests.request("POST", url, data=payload, headers=headers)
 


### PR DESCRIPTION
This cleans up the snippets that are coming from the Python `requests` client to:

* [x] Ensure that all dict keys are wrapped in double quotes (most everything already was)
* [x] For `application/json` requests, we now build out Python-compatible dicts and send pass those to `requests` via the `json=payload` argument that it provides.
  * With this work, `false`, `true`, and `null` are now being translated into the Python-proper literals of `False`, `True`, and `None`.