### PR TITLE
fix: updating the node-fetch target to handle form-urlencoded requests

### DIFF
--- a/test/fixtures/output/node/fetch/application-form-encoded.js
+++ b/test/fixtures/output/node/fetch/application-form-encoded.js
@@ -1,11 +1,16 @@
+const { URLSearchParams } = require('url');
 const fetch = require('node-fetch');
+const encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
+encodedParams.set('hello', 'world');
 
 let url = 'http://mockbin.com/har';
 
 let options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  body: {foo: 'bar', hello: 'world'}
+  body: encodedParams.toString()
 };
 
 fetch(url, options)

--- a/test/fixtures/output/node/fetch/full.js
+++ b/test/fixtures/output/node/fetch/full.js
@@ -1,4 +1,8 @@
+const { URLSearchParams } = require('url');
 const fetch = require('node-fetch');
+const encodedParams = new URLSearchParams();
+
+encodedParams.set('foo', 'bar');
 
 let url = 'http://mockbin.com/har';
 
@@ -10,7 +14,7 @@ let options = {
     'content-type': 'application/x-www-form-urlencoded',
     cookie: 'foo=bar; bar=baz; '
   },
-  body: {foo: 'bar'}
+  body: encodedParams.toString()
 };
 
 fetch(url, options)

--- a/test/fixtures/output/node/fetch/multipart-form-data.js
+++ b/test/fixtures/output/node/fetch/multipart-form-data.js
@@ -1,7 +1,8 @@
 const FormData = require('form-data');
 const fetch = require('node-fetch');
 const formData = new FormData();
-formData.append('foo','bar');
+
+formData.append('foo', 'bar');
 
 let url = 'http://mockbin.com/har';
 


### PR DESCRIPTION
The `node-fetch` target was originally sending `x-www-form-urlencoded` as a JSON object to `body` when it should be encoded with `URLSearchParams`.