### PR TITLE
fix: simplifying node-fetch snippets with urlsearchparams

### DIFF
--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -45,7 +45,7 @@ module.exports = function (source, options) {
         code.push('encodedParams.set(\'' + param.name + '\', \'' + param.value + '\');')
       })
 
-      reqOpts.body = 'encodedParams.toString()'
+      reqOpts.body = 'encodedParams'
       break
 
     case 'application/json':
@@ -110,7 +110,7 @@ module.exports = function (source, options) {
       .push(1, '.catch(err => console.error(\'error:\' + err));')
 
   return code.join()
-    .replace(/'encodedParams.toString\(\)'/, 'encodedParams.toString()')
+    .replace(/'encodedParams'/, 'encodedParams')
     .replace(/"fs\.createReadStream\(\\"(.+)\\"\)"/, 'fs.createReadStream("$1")')
 }
 

--- a/test/fixtures/output/node/fetch/application-form-encoded.js
+++ b/test/fixtures/output/node/fetch/application-form-encoded.js
@@ -10,7 +10,7 @@ let url = 'http://mockbin.com/har';
 let options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  body: encodedParams.toString()
+  body: encodedParams
 };
 
 fetch(url, options)

--- a/test/fixtures/output/node/fetch/full.js
+++ b/test/fixtures/output/node/fetch/full.js
@@ -14,7 +14,7 @@ let options = {
     'content-type': 'application/x-www-form-urlencoded',
     cookie: 'foo=bar; bar=baz; '
   },
-  body: encodedParams.toString()
+  body: encodedParams
 };
 
 fetch(url, options)


### PR DESCRIPTION
`node-fetch` can accept URLSearchParams directly without having to translate it to a string first.