### PR TITLE
feat: add useObjectBody flag for better request body readability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2.3.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2.3.3

--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ Type: `object`
 
 Target options, *see [wiki](https://github.com/kong/httpsnippet/wiki/Targets) for details*
 
-*Note: This fork has added "useObjectBody" to the node target, a boolean flag that includes an object literal wrapped in JSON.stringify, as opposed to a string object body.*
-
-
 ```js
 const HTTPSnippet = require('httpsnippet');
 
@@ -152,6 +149,7 @@ The main difference between this library and the upstream [httpsnippet](https://
 
 * This targets Node 10+
 * Does not ship with a CLI component
+* Adds a `useObjectBody` option to the node target. This option is a boolean flag that causes the request body to be rendered as an object literal wrapped in `JSON.stringify`. If disabled, it falls back to the original behavior of a stringified object body. This flag defaults to disabled.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Type: `object`
 
 Target options, *see [wiki](https://github.com/kong/httpsnippet/wiki/Targets) for details*
 
+*Note: This fork has added "useObjectBody" to the node target, a boolean flag that includes an object literal wrapped in JSON.stringify, as opposed to a string object body.*
+
+
 ```js
 const HTTPSnippet = require('httpsnippet');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/httpsnippet",
-  "version": "2.1.1",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.3",
+  "version": "2.3.0",
   "name": "@readme/httpsnippet",
   "description": "HTTP Request snippet generator for *most* languages",
   "homepage": "https://github.com/readmeio/httpsnippet",

--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -94,19 +94,19 @@ module.exports = function (source, options) {
   code.blank()
   code.push('let url = \'' + url + '\';')
     .blank()
-  code.push('let options = %s;', stringifyObject(reqOpts, { 
-    indent: '  ', 
+  code.push('let options = %s;', stringifyObject(reqOpts, {
+    indent: '  ',
     inlineCharacterLimit: 80,
     // The Fetch API body only accepts string parameters, but stringified JSON
     // can be difficult to read, so if you pass the useObjectBody param
-    // we keep the object as a literal and use this transform function 
+    // we keep the object as a literal and use this transform function
     // to wrap the literal in a JSON.stringify call
     transform: (object, property, originalResult) => {
       if (property === 'body' && options.useObjectBody) {
-        return 'JSON.stringify(' + originalResult + ')';
+        return 'JSON.stringify(' + originalResult + ')'
       }
 
-      return originalResult;
+      return originalResult
     }}))
     .blank()
 

--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -50,7 +50,7 @@ module.exports = function (source, options) {
 
     case 'application/json':
       if (source.postData.jsonObj) {
-        reqOpts.body = JSON.stringify(source.postData.jsonObj)
+        reqOpts.body = options.useObjectBody ? source.postData.jsonObj : JSON.stringify(source.postData.jsonObj)
       }
       break
 
@@ -94,7 +94,20 @@ module.exports = function (source, options) {
   code.blank()
   code.push('let url = \'' + url + '\';')
     .blank()
-  code.push('let options = %s;', stringifyObject(reqOpts, { indent: '  ', inlineCharacterLimit: 80 }))
+  code.push('let options = %s;', stringifyObject(reqOpts, { 
+    indent: '  ', 
+    inlineCharacterLimit: 80,
+    // The Fetch API body only accepts string parameters, but stringified JSON
+    // can be difficult to read, so if you pass the useObjectBody param
+    // we keep the object as a literal and use this transform function 
+    // to wrap the literal in a JSON.stringify call
+    transform: (object, property, originalResult) => {
+      if (property === 'body' && options.useObjectBody) {
+        return 'JSON.stringify(' + originalResult + ')';
+      }
+
+      return originalResult;
+    }}))
     .blank()
 
   if (includeFS) {

--- a/test/targets/node/fetch.js
+++ b/test/targets/node/fetch.js
@@ -1,3 +1,59 @@
+/* global it */
+
 'use strict'
 
-module.exports = function (snippet, fixtures) {}
+require('should')
+
+module.exports = function (HTTPSnippet, fixtures) {
+  it('should respond properly when useObjectBody is enabled', function () {
+    var result = new HTTPSnippet(fixtures.requests['application-json']).convert('node', 'fetch', {
+      useObjectBody: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`const fetch = require('node-fetch');
+
+let url = 'http://mockbin.com/har';
+
+let options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: JSON.stringify({
+    number: 1,
+    string: 'f"oo',
+    arr: [1, 2, 3],
+    nested: {a: 'b'},
+    arr_mix: [1, 'a', {arr_mix_nested: {}}],
+    boolean: false
+  })
+};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));`)
+  })
+
+  it('should respond properly when useObjectBody is disabled', function () {
+    var result = new HTTPSnippet(fixtures.requests['application-json']).convert('node', 'fetch', {
+      useObjectBody: false
+    })
+
+    result.should.be.a.String()
+    // This is identical to /test/fixtures/output/node/fetch/application-json.js, but /test/fixtures/index.js explicitly excludes output, leaving me to copy and paste for the moment.
+    result.should.eql(`const fetch = require('node-fetch');
+
+let url = 'http://mockbin.com/har';
+
+let options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: '{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'
+};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));`)
+  })
+}


### PR DESCRIPTION
Original Ticket: https://app.asana.com/0/1199087650851461/1198986894847661

This PR adds the flag `useObjectBody` to `httpsnippet.convert`'s second parameter, `options`. That flag causes the request body to be included as an object literal wrapped in `JSON.stringify`, as opposed to showing the object as a string literal.

**Old Format**
<img width="410" alt="Screen Shot 2020-11-18 at 12 20 59 PM" src="https://user-images.githubusercontent.com/218751/99564509-8fd80980-2998-11eb-8af3-d0b19942d922.png">


**New Format**
<img width="558" alt="Screen Shot 2020-11-18 at 12 18 25 PM" src="https://user-images.githubusercontent.com/218751/99564453-7931b280-2998-11eb-9bb5-4a391f1bd259.png">

Next up we need to get api-explorer to use this version of the library, and enable this flag.