### PR TITLE
feat: extending the useObjectBody option to JS fetch()

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The main difference between this library and the upstream [httpsnippet](https://
 
 * This targets Node 10+
 * Does not ship with a CLI component
-* Adds a `useObjectBody` option to the node target. This option is a boolean flag that causes the request body to be rendered as an object literal wrapped in `JSON.stringify`. If disabled, it falls back to the original behavior of a stringified object body. This flag defaults to disabled.
+* Adds a `useObjectBody` option to the `node` and `javascript` targets. This option is a boolean flag that causes the request body to be rendered as an object literal wrapped in `JSON.stringify`. If disabled, it falls back to the original behavior of a stringified object body. This flag defaults to disabled.
 
 ## License
 

--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -25,8 +25,11 @@ module.exports = function (source, options) {
   var code = new CodeBuilder(opts.indent)
 
   options = {
-    method: source.method,
-    headers: source.allHeaders
+    method: source.method
+  }
+
+  if (Object.keys(source.allHeaders).length) {
+    options.headers = source.allHeaders
   }
 
   if (opts.credentials !== null) {

--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -10,6 +10,7 @@
 
 'use strict'
 
+var stringifyObject = require('stringify-object')
 var CodeBuilder = require('../../helpers/code-builder')
 
 module.exports = function (source, options) {
@@ -40,7 +41,7 @@ module.exports = function (source, options) {
       break
 
     case 'application/json':
-      options.body = JSON.stringify(source.postData.jsonObj)
+      options.body = opts.useObjectBody ? source.postData.jsonObj : JSON.stringify(source.postData.jsonObj)
       break
 
     case 'multipart/form-data':
@@ -63,14 +64,31 @@ module.exports = function (source, options) {
       }
   }
 
-  code
-    .push(`fetch("${source.fullUrl}", ${JSON.stringify(options, null, opts.indent)})`)
-    .push('.then(response => {')
-    .push(1, 'console.log(response);')
-    .push('})')
-    .push('.catch(err => {')
-    .push(1, 'console.error(err);')
-    .push('});')
+  code.push('const options = %s;', stringifyObject(options, {
+    indent: opts.indent,
+    inlineCharacterLimit: 80,
+
+    // The Fetch API body only accepts string parameters, but stringified JSON can be difficult to
+    // read, so if you pass the `useObjectBody` option we keep the object as a literal and use
+    // this transform function to wrap the literal in a `JSON.stringify` call.
+    transform: (object, property, originalResult) => {
+      if (property === 'body' && opts.useObjectBody && source.postData.mimeType === 'application/json') {
+        return 'JSON.stringify(' + originalResult + ')'
+      }
+
+      return originalResult
+    }
+  }))
+    .blank()
+
+  if (source.postData.mimeType === 'multipart/form-data') {
+    code.push('options.body = form;')
+      .blank()
+  }
+
+  code.push("fetch('%s', options)", source.fullUrl)
+    .push(1, '.then(response => console.log(response))')
+    .push(1, '.catch(err => console.error(err));')
 
   return code.join()
 }

--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -84,6 +84,7 @@ module.exports = function (source, options) {
     source.cookies.forEach(function (cookie) {
       cookies = cookies + encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value) + '; '
     })
+
     if (reqOpts.headers) {
       reqOpts.headers.cookie = cookies
     } else {
@@ -91,18 +92,19 @@ module.exports = function (source, options) {
       reqOpts.headers.cookie = cookies
     }
   }
+
   code.blank()
-  code.push('let url = \'' + url + '\';')
+  code.push('const url = \'' + url + '\';')
     .blank()
-  code.push('let options = %s;', stringifyObject(reqOpts, {
-    indent: '  ',
+  code.push('const options = %s;', stringifyObject(reqOpts, {
+    indent: opts.indent,
     inlineCharacterLimit: 80,
-    // The Fetch API body only accepts string parameters, but stringified JSON
-    // can be difficult to read, so if you pass the useObjectBody param
-    // we keep the object as a literal and use this transform function
-    // to wrap the literal in a JSON.stringify call
+
+    // The Fetch API body only accepts string parameters, but stringified JSON can be difficult to
+    // read, so if you pass the `useObjectBody` option we keep the object as a literal and use
+    // this transform function to wrap the literal in a `JSON.stringify` call.
     transform: (object, property, originalResult) => {
-      if (property === 'body' && options.useObjectBody && source.postData.mimeType === 'application/json') {
+      if (property === 'body' && opts.useObjectBody && source.postData.mimeType === 'application/json') {
         return 'JSON.stringify(' + originalResult + ')'
       }
 
@@ -113,10 +115,12 @@ module.exports = function (source, options) {
   if (includeFS) {
     code.unshift('const fs = require(\'fs\');')
   }
+
   if (source.postData.mimeType === 'multipart/form-data') {
     code.push('options.body = formData;')
       .blank()
   }
+
   code.push('fetch(url, options)')
       .push(1, '.then(res => res.json())')
       .push(1, '.then(json => console.log(json))')

--- a/test/fixtures/output/javascript/fetch/application-form-encoded.js
+++ b/test/fixtures/output/javascript/fetch/application-form-encoded.js
@@ -1,16 +1,9 @@
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "content-type": "application/x-www-form-urlencoded"
-  },
-  "body": {
-    "foo": "bar",
-    "hello": "world"
-  }
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/x-www-form-urlencoded'},
+  body: {foo: 'bar', hello: 'world'}
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/application-json.js
+++ b/test/fixtures/output/javascript/fetch/application-json.js
@@ -1,13 +1,9 @@
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "content-type": "application/json"
-  },
-  "body": "{\"number\":1,\"string\":\"f\\\"oo\",\"arr\":[1,2,3],\"nested\":{\"a\":\"b\"},\"arr_mix\":[1,\"a\",{\"arr_mix_nested\":{}}],\"boolean\":false}"
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/cookies.js
+++ b/test/fixtures/output/javascript/fetch/cookies.js
@@ -1,12 +1,5 @@
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "cookie": "foo=bar; bar=baz"
-  }
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz'}};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/custom-method.js
+++ b/test/fixtures/output/javascript/fetch/custom-method.js
@@ -1,4 +1,4 @@
-const options = {method: 'PROPFIND', headers: {}};
+const options = {method: 'PROPFIND'};
 
 fetch('http://mockbin.com/har', options)
   .then(response => console.log(response))

--- a/test/fixtures/output/javascript/fetch/custom-method.js
+++ b/test/fixtures/output/javascript/fetch/custom-method.js
@@ -1,10 +1,5 @@
-fetch("http://mockbin.com/har", {
-  "method": "PROPFIND",
-  "headers": {}
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'PROPFIND', headers: {}};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/full.js
+++ b/test/fixtures/output/javascript/fetch/full.js
@@ -1,17 +1,13 @@
-fetch("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value", {
-  "method": "POST",
-  "headers": {
-    "cookie": "foo=bar; bar=baz",
-    "accept": "application/json",
-    "content-type": "application/x-www-form-urlencoded"
+const options = {
+  method: 'POST',
+  headers: {
+    cookie: 'foo=bar; bar=baz',
+    accept: 'application/json',
+    'content-type': 'application/x-www-form-urlencoded'
   },
-  "body": {
-    "foo": "bar"
-  }
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+  body: {foo: 'bar'}
+};
+
+fetch('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/headers.js
+++ b/test/fixtures/output/javascript/fetch/headers.js
@@ -1,13 +1,5 @@
-fetch("http://mockbin.com/har", {
-  "method": "GET",
-  "headers": {
-    "accept": "application/json",
-    "x-foo": "Bar"
-  }
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'GET', headers: {accept: 'application/json', 'x-foo': 'Bar'}};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/https.js
+++ b/test/fixtures/output/javascript/fetch/https.js
@@ -1,10 +1,5 @@
-fetch("https://mockbin.com/har", {
-  "method": "GET",
-  "headers": {}
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'GET', headers: {}};
+
+fetch('https://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/https.js
+++ b/test/fixtures/output/javascript/fetch/https.js
@@ -1,4 +1,4 @@
-const options = {method: 'GET', headers: {}};
+const options = {method: 'GET'};
 
 fetch('https://mockbin.com/har', options)
   .then(response => console.log(response))

--- a/test/fixtures/output/javascript/fetch/jsonObj-multiline.js
+++ b/test/fixtures/output/javascript/fetch/jsonObj-multiline.js
@@ -1,13 +1,9 @@
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "content-type": "application/json"
-  },
-  "body": "{\"foo\":\"bar\"}"
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: '{"foo":"bar"}'
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/jsonObj-null-value.js
+++ b/test/fixtures/output/javascript/fetch/jsonObj-null-value.js
@@ -1,13 +1,9 @@
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "content-type": "application/json"
-  },
-  "body": "{\"foo\":null}"
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: '{"foo":null}'
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/multipart-data.js
+++ b/test/fixtures/output/javascript/fetch/multipart-data.js
@@ -1,15 +1,13 @@
 const form = new FormData();
 form.append("foo", "Hello World");
 
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "content-type": "multipart/form-data; boundary=---011000010111000001101001"
-  }
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {
+  method: 'POST',
+  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+};
+
+options.body = form;
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/multipart-file.js
+++ b/test/fixtures/output/javascript/fetch/multipart-file.js
@@ -1,15 +1,13 @@
 const form = new FormData();
 form.append("foo", "test/fixtures/files/hello.txt");
 
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "content-type": "multipart/form-data; boundary=---011000010111000001101001"
-  }
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {
+  method: 'POST',
+  headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
+};
+
+options.body = form;
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/multipart-form-data.js
+++ b/test/fixtures/output/javascript/fetch/multipart-form-data.js
@@ -1,15 +1,13 @@
 const form = new FormData();
 form.append("foo", "bar");
 
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "Content-Type": "multipart/form-data; boundary=---011000010111000001101001"
-  }
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {
+  method: 'POST',
+  headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
+};
+
+options.body = form;
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/query.js
+++ b/test/fixtures/output/javascript/fetch/query.js
@@ -1,10 +1,5 @@
-fetch("http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value", {
-  "method": "GET",
-  "headers": {}
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'GET', headers: {}};
+
+fetch('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/query.js
+++ b/test/fixtures/output/javascript/fetch/query.js
@@ -1,4 +1,4 @@
-const options = {method: 'GET', headers: {}};
+const options = {method: 'GET'};
 
 fetch('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', options)
   .then(response => console.log(response))

--- a/test/fixtures/output/javascript/fetch/short.js
+++ b/test/fixtures/output/javascript/fetch/short.js
@@ -1,4 +1,4 @@
-const options = {method: 'GET', headers: {}};
+const options = {method: 'GET'};
 
 fetch('http://mockbin.com/har', options)
   .then(response => console.log(response))

--- a/test/fixtures/output/javascript/fetch/short.js
+++ b/test/fixtures/output/javascript/fetch/short.js
@@ -1,10 +1,5 @@
-fetch("http://mockbin.com/har", {
-  "method": "GET",
-  "headers": {}
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'GET', headers: {}};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/javascript/fetch/text-plain.js
+++ b/test/fixtures/output/javascript/fetch/text-plain.js
@@ -1,13 +1,5 @@
-fetch("http://mockbin.com/har", {
-  "method": "POST",
-  "headers": {
-    "content-type": "text/plain"
-  },
-  "body": "Hello World"
-})
-.then(response => {
-  console.log(response);
-})
-.catch(err => {
-  console.error(err);
-});
+const options = {method: 'POST', headers: {'content-type': 'text/plain'}, body: 'Hello World'};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/test/fixtures/output/node/fetch/application-form-encoded.js
+++ b/test/fixtures/output/node/fetch/application-form-encoded.js
@@ -5,9 +5,9 @@ const encodedParams = new URLSearchParams();
 encodedParams.set('foo', 'bar');
 encodedParams.set('hello', 'world');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
   body: encodedParams

--- a/test/fixtures/output/node/fetch/application-json.js
+++ b/test/fixtures/output/node/fetch/application-json.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"number":1,"string":"f\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'

--- a/test/fixtures/output/node/fetch/cookies.js
+++ b/test/fixtures/output/node/fetch/cookies.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz; '}};
+const options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz; '}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/fetch/custom-method.js
+++ b/test/fixtures/output/node/fetch/custom-method.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {method: 'PROPFIND'};
+const options = {method: 'PROPFIND'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/fetch/full.js
+++ b/test/fixtures/output/node/fetch/full.js
@@ -4,9 +4,9 @@ const encodedParams = new URLSearchParams();
 
 encodedParams.set('foo', 'bar');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   qs: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'},
   headers: {

--- a/test/fixtures/output/node/fetch/headers.js
+++ b/test/fixtures/output/node/fetch/headers.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {method: 'GET', headers: {accept: 'application/json', 'x-foo': 'Bar'}};
+const options = {method: 'GET', headers: {accept: 'application/json', 'x-foo': 'Bar'}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/fetch/https.js
+++ b/test/fixtures/output/node/fetch/https.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'https://mockbin.com/har';
+const url = 'https://mockbin.com/har';
 
-let options = {method: 'GET'};
+const options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/fetch/jsonObj-multiline.js
+++ b/test/fixtures/output/node/fetch/jsonObj-multiline.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"foo":"bar"}'

--- a/test/fixtures/output/node/fetch/jsonObj-null-value.js
+++ b/test/fixtures/output/node/fetch/jsonObj-null-value.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"foo":null}'

--- a/test/fixtures/output/node/fetch/multipart-data.js
+++ b/test/fixtures/output/node/fetch/multipart-data.js
@@ -5,9 +5,9 @@ const formData = new FormData();
 
 formData.append('foo', fs.createReadStream('hello.txt'));
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
 };

--- a/test/fixtures/output/node/fetch/multipart-file.js
+++ b/test/fixtures/output/node/fetch/multipart-file.js
@@ -5,9 +5,9 @@ const formData = new FormData();
 
 formData.append('foo', fs.createReadStream('test/fixtures/files/hello.txt'));
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'multipart/form-data; boundary=---011000010111000001101001'}
 };

--- a/test/fixtures/output/node/fetch/multipart-form-data.js
+++ b/test/fixtures/output/node/fetch/multipart-form-data.js
@@ -4,9 +4,9 @@ const formData = new FormData();
 
 formData.append('foo', 'bar');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'Content-Type': 'multipart/form-data; boundary=---011000010111000001101001'}
 };

--- a/test/fixtures/output/node/fetch/query.js
+++ b/test/fixtures/output/node/fetch/query.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {method: 'GET', qs: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}};
+const options = {method: 'GET', qs: {foo: ['bar', 'baz'], baz: 'abc', key: 'value'}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/fetch/short.js
+++ b/test/fixtures/output/node/fetch/short.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {method: 'GET'};
+const options = {method: 'GET'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/fetch/text-plain.js
+++ b/test/fixtures/output/node/fetch/text-plain.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {method: 'POST', headers: {'content-type': 'text/plain'}, body: 'Hello World'};
+const options = {method: 'POST', headers: {'content-type': 'text/plain'}, body: 'Hello World'};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/targets/javascript/fetch.js
+++ b/test/targets/javascript/fetch.js
@@ -1,3 +1,65 @@
+/* global it */
+
 'use strict'
 
-module.exports = function (snippet, fixtures) {}
+require('should')
+
+module.exports = function (HTTPSnippet, fixtures) {
+  it('should respond with stringify when `useObjectBody` is enabled', function () {
+    var result = new HTTPSnippet(fixtures.requests['application-json']).convert('javascript', 'fetch', {
+      useObjectBody: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: JSON.stringify({
+    number: 1,
+    string: 'f"oo',
+    arr: [1, 2, 3],
+    nested: {a: 'b'},
+    arr_mix: [1, 'a', {arr_mix_nested: {}}],
+    boolean: false
+  })
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));`)
+  })
+
+  it('should respond without stringify when `useObjectBody` is disabled', function () {
+    var result = new HTTPSnippet(fixtures.requests['application-json']).convert('javascript', 'fetch', {
+      useObjectBody: false
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/json'},
+  body: '{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));`)
+  })
+
+  it('should respond without stringify when useObjectBody is enabled on URLSearchParams', function () {
+    var result = new HTTPSnippet(fixtures.requests['application-form-encoded']).convert('javascript', 'fetch', {
+      useObjectBody: true
+    })
+
+    result.should.be.a.String()
+    result.should.eql(`const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/x-www-form-urlencoded'},
+  body: {foo: 'bar', hello: 'world'}
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => console.log(response))
+  .catch(err => console.error(err));`)
+  })
+}

--- a/test/targets/node/fetch.js
+++ b/test/targets/node/fetch.js
@@ -13,9 +13,9 @@ module.exports = function (HTTPSnippet, fixtures) {
     result.should.be.a.String()
     result.should.eql(`const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: JSON.stringify({
@@ -43,9 +43,9 @@ fetch(url, options)
     // This is identical to /test/fixtures/output/node/fetch/application-json.js, but /test/fixtures/index.js explicitly excludes output, leaving me to copy and paste for the moment.
     result.should.eql(`const fetch = require('node-fetch');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'
@@ -71,9 +71,9 @@ const encodedParams = new URLSearchParams();
 encodedParams.set('foo', 'bar');
 encodedParams.set('hello', 'world');
 
-let url = 'http://mockbin.com/har';
+const url = 'http://mockbin.com/har';
 
-let options = {
+const options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
   body: encodedParams


### PR DESCRIPTION
* [x] Extends the `useObjectBody` option we added for the `node-fetch` target over to the JS `fetch()` target to generate `body` JSON payloads within a `JSON.stringify()` call in the snippet instead of the body actually being JSON stringified. This is identical to how the `node-fetch` target handles this option.
* [x] Cleaned up the JS fetch snippets a bit by hoisting `fetch` options up into an `options` constant, and removed some noise around the promise handling for them.
  * Also changed the `node-fetch` snippets to use `const` instead of `let`.
* [x] Fixed a bug in the `multipart/form-data` JS fetch snippets where the `FormData` variable wasn't actually being sent in the request.

Fixes RM-44