### PR TITLE
fix: swapping the querystring engine for one doesn't need to be polyfilled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/httpsnippet",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2563,6 +2563,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "event-stream": "4.0.1",
     "form-data": "3.0.0",
     "har-validator": "^5.0.0",
+    "qs": "^6.9.6",
     "stringify-object": "^3.3.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 
 var es = require('event-stream')
 var MultiPartForm = require('form-data')
-var qs = require('querystring')
+var qs = require('qs')
 var reducer = require('./helpers/reducer')
 var targets = require('./targets')
 var url = require('url')
@@ -232,12 +232,13 @@ HTTPSnippet.prototype.prepare = function (request, options) {
   // update the uri object
   request.uriObj.query = request.queryObj
   if (options.escapeQueryStrings) {
-    request.uriObj.search = qs.stringify(request.queryObj)
+    request.uriObj.search = qs.stringify(request.queryObj, {
+      indices: false
+    })
   } else {
-    // If we don't want to escape query strings (in the case of the HAR already having them escaped), pass in a dumb
-    // callback to disable querystring from doing so.
-    request.uriObj.search = qs.stringify(request.queryObj, null, null, {
-      encodeURIComponent: (str) => str
+    request.uriObj.search = qs.stringify(request.queryObj, {
+      encode: false,
+      indices: false
     })
   }
 


### PR DESCRIPTION
So a fun problem cropped up with #33: it doesn't work in the browser.

Fun fact: Did you know that the polyfill Webpack 4 injects for `querystring` doesn't match the API of Node's `querystring` module? It supports everything but the 4th argument to override `encodeURIComponent`.

This rips it out of the library and swaps it with [qs](https://npm.im/qs), a query string handler that doesn't need to be polyfilled in the browser.