### PR TITLE
switch ruby ssl from verify_none to verify_peer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/httpsnippet",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.1",
+  "version": "2.4.2",
   "name": "@readme/httpsnippet",
   "description": "HTTP Request snippet generator for *most* languages",
   "homepage": "https://github.com/readmeio/httpsnippet",

--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -34,7 +34,6 @@ module.exports = function (source, options) {
 
   if (source.uriObj.protocol === 'https:') {
     code.push('http.use_ssl = true')
-        .push('http.verify_mode = OpenSSL::SSL::VERIFY_PEER')
   }
 
   code.blank()

--- a/src/targets/ruby/native.js
+++ b/src/targets/ruby/native.js
@@ -34,7 +34,7 @@ module.exports = function (source, options) {
 
   if (source.uriObj.protocol === 'https:') {
     code.push('http.use_ssl = true')
-        .push('http.verify_mode = OpenSSL::SSL::VERIFY_NONE')
+        .push('http.verify_mode = OpenSSL::SSL::VERIFY_PEER')
   }
 
   code.blank()

--- a/test/fixtures/output/ruby/native/https.rb
+++ b/test/fixtures/output/ruby/native/https.rb
@@ -6,7 +6,6 @@ url = URI("https://mockbin.com/har")
 
 http = Net::HTTP.new(url.host, url.port)
 http.use_ssl = true
-http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
 request = Net::HTTP::Get.new(url)
 

--- a/test/fixtures/output/ruby/native/https.rb
+++ b/test/fixtures/output/ruby/native/https.rb
@@ -6,7 +6,7 @@ url = URI("https://mockbin.com/har")
 
 http = Net::HTTP.new(url.host, url.port)
 http.use_ssl = true
-http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
 request = Net::HTTP::Get.new(url)
 


### PR DESCRIPTION
The option `http.verify_mode = OpenSSL::SSL::VERIFY_NONE` in the ruby native target bypasses ssl certificate verification. This changes that setting to `http.verify_mode = OpenSSL::SSL::VERIFY_PEER`, a more secure option.

It is also the default option, but I think being explicit has its benefits, such as making the option visible for newcomers who have certificate issues.