### PR TITLE
fix: not sending form urlencoded properly in JS fetch snippets

### DIFF
--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -77,8 +77,16 @@ module.exports = function (source, options) {
     // read, so if you pass the `useObjectBody` option we keep the object as a literal and use
     // this transform function to wrap the literal in a `JSON.stringify` call.
     transform: (object, property, originalResult) => {
-      if (property === 'body' && opts.useObjectBody && source.postData.mimeType === 'application/json') {
-        return 'JSON.stringify(' + originalResult + ')'
+      if (property === 'body') {
+        if (source.postData.mimeType === 'application/x-www-form-urlencoded') {
+          return `new URLSearchParams(${originalResult})`
+        }
+
+        if (opts.useObjectBody) {
+          if (source.postData.mimeType === 'application/json') {
+            return 'JSON.stringify(' + originalResult + ')'
+          }
+        }
       }
 
       return originalResult

--- a/test/fixtures/output/javascript/fetch/application-form-encoded.js
+++ b/test/fixtures/output/javascript/fetch/application-form-encoded.js
@@ -1,7 +1,7 @@
 const options = {
   method: 'POST',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  body: {foo: 'bar', hello: 'world'}
+  body: new URLSearchParams({foo: 'bar', hello: 'world'})
 };
 
 fetch('http://mockbin.com/har', options)

--- a/test/fixtures/output/javascript/fetch/full.js
+++ b/test/fixtures/output/javascript/fetch/full.js
@@ -5,7 +5,7 @@ const options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  body: {foo: 'bar'}
+  body: new URLSearchParams({foo: 'bar'})
 };
 
 fetch('http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value', options)

--- a/test/targets/javascript/fetch.js
+++ b/test/targets/javascript/fetch.js
@@ -1,17 +1,18 @@
-/* global it */
+/* global it, describe */
 
 'use strict'
 
 require('should')
 
 module.exports = function (HTTPSnippet, fixtures) {
-  it('should respond with stringify when `useObjectBody` is enabled', function () {
-    var result = new HTTPSnippet(fixtures.requests['application-json']).convert('javascript', 'fetch', {
-      useObjectBody: true
-    })
+  describe('`useObjectBody` is enabled', () => {
+    it('should respond with stringify on `application/json` requests', function () {
+      var result = new HTTPSnippet(fixtures.requests['application-json']).convert('javascript', 'fetch', {
+        useObjectBody: true
+      })
 
-    result.should.be.a.String()
-    result.should.eql(`const options = {
+      result.should.be.a.String()
+      result.should.eql(`const options = {
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: JSON.stringify({
@@ -28,6 +29,25 @@ fetch('http://mockbin.com/har', options)
   .then(response => response.json())
   .then(response => console.log(response))
   .catch(err => console.error(err));`)
+    })
+
+    it('should respond without stringify on `application-form-encoded` requests', function () {
+      var result = new HTTPSnippet(fixtures.requests['application-form-encoded']).convert('javascript', 'fetch', {
+        useObjectBody: true
+      })
+
+      result.should.be.a.String()
+      result.should.eql(`const options = {
+  method: 'POST',
+  headers: {'content-type': 'application/x-www-form-urlencoded'},
+  body: new URLSearchParams({foo: 'bar', hello: 'world'})
+};
+
+fetch('http://mockbin.com/har', options)
+  .then(response => response.json())
+  .then(response => console.log(response))
+  .catch(err => console.error(err));`)
+    })
   })
 
   it('should respond without stringify when `useObjectBody` is disabled', function () {
@@ -40,24 +60,6 @@ fetch('http://mockbin.com/har', options)
   method: 'POST',
   headers: {'content-type': 'application/json'},
   body: '{"number":1,"string":"f\\"oo","arr":[1,2,3],"nested":{"a":"b"},"arr_mix":[1,"a",{"arr_mix_nested":{}}],"boolean":false}'
-};
-
-fetch('http://mockbin.com/har', options)
-  .then(response => response.json())
-  .then(response => console.log(response))
-  .catch(err => console.error(err));`)
-  })
-
-  it('should respond without stringify when useObjectBody is enabled on URLSearchParams', function () {
-    var result = new HTTPSnippet(fixtures.requests['application-form-encoded']).convert('javascript', 'fetch', {
-      useObjectBody: true
-    })
-
-    result.should.be.a.String()
-    result.should.eql(`const options = {
-  method: 'POST',
-  headers: {'content-type': 'application/x-www-form-urlencoded'},
-  body: {foo: 'bar', hello: 'world'}
 };
 
 fetch('http://mockbin.com/har', options)


### PR DESCRIPTION
JS `fetch` body needs to be a string, and we were sending objects on `x-www-url-formencoded` requests. This fixes that by wrapping those objects in `new URLSearchParams`.