### PR TITLE
fix: add new option for escaping brackets in curl snippets

### DIFF
--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -20,7 +20,8 @@ module.exports = function (source, options) {
     indent: '  ',
     short: false,
     binary: false,
-    globOff: false
+    globOff: false,
+    escapeBrackets: false
   }, options)
 
   const code = new CodeBuilder(opts.indent, opts.indent !== false ? ' \\\n' + opts.indent : ' ')
@@ -28,6 +29,10 @@ module.exports = function (source, options) {
   const globOption = opts.short ? '-g' : '--globoff'
   const requestOption = opts.short ? '-X' : '--request'
   let formattedUrl = helpers.quote(source.fullUrl)
+
+  if (opts.escapeBrackets) {
+    formattedUrl = formattedUrl.replace(/\[/g, '\\[').replace(/\]/g, '\\]')
+  }
 
   code.push('curl %s %s', requestOption, source.method)
   if (opts.globOff) {

--- a/test/targets/shell/curl.js
+++ b/test/targets/shell/curl.js
@@ -64,6 +64,27 @@ module.exports = function (HTTPSnippet, fixtures) {
     result.should.eql('curl --request GET --url http://mockbin.com/request --http1.0')
   })
 
+  it('should escape brackets in query strings when `escapeQueryStrings` is `false` and `escapeBrackets` is `true`', function () {
+    const har = {
+      method: 'GET',
+      url: 'http://mockbin.com/har',
+      httpVersion: 'HTTP/1.1',
+      queryString: [
+        {
+          name: 'where',
+          value: '[["$attributed_flow","=","FLOW_ID"]]'
+        }
+      ]
+    }
+
+    const result = new HTTPSnippet(har, { escapeQueryStrings: false }).convert('shell', 'curl', {
+      escapeBrackets: true
+    })
+
+    result.should.be.a.String()
+    result.replace(/\\\n/g, '').should.eql("curl --request GET   --url 'http://mockbin.com/har?where=\\[\\[\"$attributed_flow\",\"=\",\"FLOW_ID\"\\]\\]'")
+  })
+
   it('should use custom indentation', function () {
     const result = new HTTPSnippet(fixtures.requests.full).convert('shell', 'curl', {
       indent: '@'


### PR DESCRIPTION
This fixes a case where because we pass `escapeQueryStrings: false` to HTTPSnippet and don't escape query strings (instead relying on OAS style configurations), query strings in cURL snippets like `[["$attributed_flow","=","FLOW_ID"]]` wouldn't be escaped if the OAS doesn't use styles, resulting in a cURL snippet that couldn't actually be run.

```shell
$ curl --request GET \
>   --url 'https://mockbin.org/?where=[["$attributed_flow","=","FLOW_ID"]]' \
>   --header 'Accept: application/json'
curl: (3) [globbing] bad range specification in column 29
```

This fixes this problem by adding a new option to the cURL target called `escapeBrackets` that when present will manually escape `[` and `]`in the `fullUrl` data that it uses to chuck into the `--url` argument.

Resolves CX-347