### PR TITLE
feat: adding a new `harIsAlreadyEncoded` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Type: `object`
 
 Available options:
 
-* `escapeQueryStrings` (`boolean`): In the event of you supplying a `source` that alreay contains escaped query strings, this allows you to disable automatic of query strings and prevents them from being double-escaped.
+* `harIsAlreadyEncoded` (`boolean`): In the event of you supplying a `source` HAR that already contains escaped data (query and cookie parameters)strings, this allows you to disable automatic encoding of those parameters to prevent them from being double-escaped.
 
 ### convert(target [, options])
 
@@ -155,10 +155,9 @@ For detailed information on each target, please review the [wiki](https://github
 
 The main difference between this library and the upstream [httpsnippet](https://github.com/Kong/httpsnippet) library are:
 
-* This targets Node 10+
 * Does not ship with a CLI component
 * Adds a `useObjectBody` option to the `node` and `javascript` targets. This option is a boolean flag that causes the request body to be rendered as an object literal wrapped in `JSON.stringify`. If disabled, it falls back to the original behavior of a stringified object body. This flag defaults to disabled.
-* Contains a `escapeQueryStrings` option on the core library to disable escaping of query strings in URLs. Helpful if the HAR being supplied already has them escaped.
+* Contains a `harIsAlreadyEncoded` option on the core library to disable [escaping](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) of cookies and query strings in URLs. Helpful if the HAR being supplied already has them escaped.
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const HTTPSnippet = function (data, opts = {}) {
   const input = Object.assign({}, data)
 
   const options = Object.assign({
-    escapeQueryStrings: true
+    harIsAlreadyEncoded: false
   }, opts)
 
   // prep the main container
@@ -96,7 +96,11 @@ HTTPSnippet.prototype.prepare = function (request, options) {
 
   // construct Cookie header
   const cookies = request.cookies.map(function (cookie) {
-    return encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value)
+    if (options.harIsAlreadyEncoded) {
+      return cookie.name + '=' + cookie.value
+    } else {
+      return encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value)
+    }
   })
 
   if (cookies.length) {
@@ -228,13 +232,13 @@ HTTPSnippet.prototype.prepare = function (request, options) {
 
   // update the uri object
   request.uriObj.query = request.queryObj
-  if (options.escapeQueryStrings) {
+  if (options.harIsAlreadyEncoded) {
     request.uriObj.search = qs.stringify(request.queryObj, {
+      encode: false,
       indices: false
     })
   } else {
     request.uriObj.search = qs.stringify(request.queryObj, {
-      encode: false,
       indices: false
     })
   }

--- a/src/targets/node/fetch.js
+++ b/src/targets/node/fetch.js
@@ -27,8 +27,8 @@ module.exports = function (source, options) {
     method: source.method
   }
 
-  if (Object.keys(source.headersObj).length) {
-    reqOpts.headers = source.headersObj
+  if (Object.keys(source.allHeaders).length) {
+    reqOpts.headers = source.allHeaders
   }
 
   switch (source.postData.mimeType) {
@@ -72,21 +72,6 @@ module.exports = function (source, options) {
       if (source.postData.text) {
         reqOpts.body = source.postData.text
       }
-  }
-
-  // construct cookies argument
-  if (source.cookies.length) {
-    let cookies = ''
-    source.cookies.forEach(function (cookie) {
-      cookies = cookies + encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value) + '; '
-    })
-
-    if (reqOpts.headers) {
-      reqOpts.headers.cookie = cookies
-    } else {
-      reqOpts.headers = {}
-      reqOpts.headers.cookie = cookies
-    }
   }
 
   code.blank()

--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -87,15 +87,18 @@ module.exports = function (source, options) {
   }
 
   // construct cookies argument
-  if (source.cookies.length) {
+  if (source.allHeaders.cookie) {
     reqOpts.jar = 'JAR'
 
     code.push('const jar = request.jar();')
 
     const url = source.url
 
-    source.cookies.forEach(function (cookie) {
-      code.push("jar.setCookie(request.cookie('%s=%s'), '%s');", encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), url)
+    // Cookies are already encoded within `source.allHeaders` so we can pull them out of that instead of doing our
+    // own encoding work.
+    source.allHeaders.cookie.split('; ').forEach(function (cookie) {
+      const [name, value] = cookie.split('=');
+      code.push("jar.setCookie(request.cookie('%s=%s'), '%s');", name, value, url)
     })
     code.blank()
   }

--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -97,7 +97,7 @@ module.exports = function (source, options) {
     // Cookies are already encoded within `source.allHeaders` so we can pull them out of that instead of doing our
     // own encoding work.
     source.allHeaders.cookie.split('; ').forEach(function (cookie) {
-      const [name, value] = cookie.split('=');
+      const [name, value] = cookie.split('=')
       code.push("jar.setCookie(request.cookie('%s=%s'), '%s');", name, value, url)
     })
     code.blank()

--- a/src/targets/node/unirest.js
+++ b/src/targets/node/unirest.js
@@ -25,11 +25,14 @@ module.exports = function (source, options) {
     .push('const req = unirest("%s", "%s");', source.method, source.url)
     .blank()
 
-  if (source.cookies.length) {
+  if (source.allHeaders.cookie) {
     code.push('const CookieJar = unirest.jar();')
 
-    source.cookies.forEach(function (cookie) {
-      code.push('CookieJar.add("%s=%s","%s");', encodeURIComponent(cookie.name), encodeURIComponent(cookie.value), source.url)
+    // Cookies are already encoded within `source.allHeaders` so we can pull them out of that instead of doing our
+    // own encoding work.
+    source.allHeaders.cookie.split('; ').forEach(function (cookie) {
+      const [name, value] = cookie.split('=')
+      code.push('CookieJar.add("%s=%s","%s");', name, value, source.url)
     })
 
     code.push('req.jar(CookieJar);')

--- a/src/targets/php/curl.js
+++ b/src/targets/php/curl.js
@@ -83,12 +83,8 @@ module.exports = function (source, options) {
   })
 
   // construct cookies
-  const cookies = source.cookies.map(function (cookie) {
-    return encodeURIComponent(cookie.name) + '=' + encodeURIComponent(cookie.value)
-  })
-
-  if (cookies.length) {
-    curlopts.push(util.format('CURLOPT_COOKIE => "%s",', cookies.join('; ')))
+  if (source.allHeaders.cookie) {
+    curlopts.push(util.format('CURLOPT_COOKIE => "%s",', source.allHeaders.cookie))
   }
 
   // construct cookies

--- a/test/fixtures/output/node/fetch/cookies.js
+++ b/test/fixtures/output/node/fetch/cookies.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 
 const url = 'http://mockbin.com/har';
-const options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz; '}};
+const options = {method: 'POST', headers: {cookie: 'foo=bar; bar=baz'}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/test/fixtures/output/node/fetch/full.js
+++ b/test/fixtures/output/node/fetch/full.js
@@ -8,9 +8,9 @@ const url = 'http://mockbin.com/har?foo=bar&foo=baz&baz=abc&key=value';
 const options = {
   method: 'POST',
   headers: {
+    cookie: 'foo=bar; bar=baz',
     accept: 'application/json',
-    'content-type': 'application/x-www-form-urlencoded',
-    cookie: 'foo=bar; bar=baz; '
+    'content-type': 'application/x-www-form-urlencoded'
   },
   body: encodedParams
 };

--- a/test/targets.js
+++ b/test/targets.js
@@ -78,7 +78,7 @@ const itShouldGenerateOutput = function (request, path, target, client) {
     const options = {}
     if (request === 'query-encoded') {
       // Query strings in this HAR are already escaped.
-      options.escapeQueryStrings = false
+      options.harIsAlreadyEncoded = true
     }
 
     const instance = new HTTPSnippet(fixtures.requests[request], options)


### PR DESCRIPTION
With the work done in https://github.com/readmeio/oas-to-har/pull/17 to ensure that query parameters are always properly encoded it was discovered that cookie parameters were being double encoded: once in `oas-to-har` and again here. Since this is obviously bad, I've refactored our existing custom `escapeQueryStrings` option to be `harIsAlreadyEncoded` (defaulting to false) so that we can now control both query string and cookie encoding behavior.

In the process of doing this I've slightly refactored a couple targets to no longer do their own cookie encoding as it's already being done in the `HTTPSnippet` constructor when it builds up a list of `allHeaders`. This refactor also allows us to not have to pass an option to `HTTPSnippet` and also to the target itself to control encoding handling because the root `HTTPSnippet` class does not currently have any way of passing down options to targets.

> 📶 &nbsp;Since this option is now more generalized than our previous `escapeQueryStrings` option was I plan on eventually submitting this work upstream.