### PR TITLE
fix: issue where if `postData.params` were missing some targets would crash

### DIFF
--- a/__tests__/__fixtures__/output/c/libcurl/multipart-form-data-no-params.c
+++ b/__tests__/__fixtures__/output/c/libcurl/multipart-form-data-no-params.c
@@ -1,0 +1,10 @@
+CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
+curl_easy_setopt(hnd, CURLOPT_URL, "https://httpbin.org/anything");
+
+struct curl_slist *headers = NULL;
+headers = curl_slist_append(headers, "Content-Type: multipart/form-data");
+curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
+
+CURLcode ret = curl_easy_perform(hnd);

--- a/__tests__/__fixtures__/output/clojure/clj_http/multipart-form-data-no-params.clj
+++ b/__tests__/__fixtures__/output/clojure/clj_http/multipart-form-data-no-params.clj
@@ -1,0 +1,3 @@
+(require '[clj-http.client :as client])
+
+(client/post "https://httpbin.org/anything" {:headers {:Content-Type "multipart/form-data"}})

--- a/__tests__/__fixtures__/output/csharp/httpclient/multipart-form-data-no-params.cs
+++ b/__tests__/__fixtures__/output/csharp/httpclient/multipart-form-data-no-params.cs
@@ -1,0 +1,12 @@
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("https://httpbin.org/anything"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/__tests__/__fixtures__/output/csharp/restsharp/multipart-form-data-no-params.cs
+++ b/__tests__/__fixtures__/output/csharp/restsharp/multipart-form-data-no-params.cs
@@ -1,0 +1,4 @@
+var client = new RestClient("https://httpbin.org/anything");
+var request = new RestRequest(Method.POST);
+request.AddHeader("Content-Type", "multipart/form-data");
+IRestResponse response = client.Execute(request);

--- a/__tests__/__fixtures__/output/go/native/multipart-form-data-no-params.go
+++ b/__tests__/__fixtures__/output/go/native/multipart-form-data-no-params.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"io/ioutil"
+)
+
+func main() {
+
+	url := "https://httpbin.org/anything"
+
+	req, _ := http.NewRequest("POST", url, nil)
+
+	req.Header.Add("Content-Type", "multipart/form-data")
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}

--- a/__tests__/__fixtures__/output/http/1.1/multipart-form-data-no-params
+++ b/__tests__/__fixtures__/output/http/1.1/multipart-form-data-no-params
@@ -1,0 +1,3 @@
+POST /anything HTTP/1.1
+Content-Type: multipart/form-data
+Host: httpbin.org

--- a/__tests__/__fixtures__/output/java/asynchttp/multipart-form-data-no-params.java
+++ b/__tests__/__fixtures__/output/java/asynchttp/multipart-form-data-no-params.java
@@ -1,0 +1,9 @@
+AsyncHttpClient client = new DefaultAsyncHttpClient();
+client.prepare("POST", "https://httpbin.org/anything")
+  .setHeader("Content-Type", "multipart/form-data")
+  .execute()
+  .toCompletableFuture()
+  .thenAccept(System.out::println)
+  .join();
+
+client.close();

--- a/__tests__/__fixtures__/output/java/nethttp/multipart-form-data-no-params.java
+++ b/__tests__/__fixtures__/output/java/nethttp/multipart-form-data-no-params.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("https://httpbin.org/anything"))
+    .header("Content-Type", "multipart/form-data")
+    .method("POST", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/__tests__/__fixtures__/output/java/okhttp/multipart-form-data-no-params.java
+++ b/__tests__/__fixtures__/output/java/okhttp/multipart-form-data-no-params.java
@@ -1,0 +1,9 @@
+OkHttpClient client = new OkHttpClient();
+
+Request request = new Request.Builder()
+  .url("https://httpbin.org/anything")
+  .post(null)
+  .addHeader("Content-Type", "multipart/form-data")
+  .build();
+
+Response response = client.newCall(request).execute();

--- a/__tests__/__fixtures__/output/java/unirest/multipart-form-data-no-params.java
+++ b/__tests__/__fixtures__/output/java/unirest/multipart-form-data-no-params.java
@@ -1,0 +1,3 @@
+HttpResponse<String> response = Unirest.post("https://httpbin.org/anything")
+  .header("Content-Type", "multipart/form-data")
+  .asString();

--- a/__tests__/__fixtures__/output/javascript/axios/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/javascript/axios/multipart-form-data-no-params.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+const options = {
+  method: 'POST',
+  url: 'https://httpbin.org/anything',
+  headers: {'Content-Type': 'multipart/form-data'}
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});

--- a/__tests__/__fixtures__/output/javascript/fetch/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/javascript/fetch/multipart-form-data-no-params.js
@@ -1,0 +1,6 @@
+const options = {method: 'POST', headers: {'Content-Type': 'multipart/form-data'}};
+
+fetch('https://httpbin.org/anything', options)
+  .then(response => response.json())
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/__tests__/__fixtures__/output/javascript/jquery/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/javascript/jquery/multipart-form-data-no-params.js
@@ -1,0 +1,13 @@
+const settings = {
+  "async": true,
+  "crossDomain": true,
+  "url": "https://httpbin.org/anything",
+  "method": "POST",
+  "headers": {
+    "Content-Type": "multipart/form-data"
+  }
+};
+
+$.ajax(settings).done(function (response) {
+  console.log(response);
+});

--- a/__tests__/__fixtures__/output/javascript/xhr/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/javascript/xhr/multipart-form-data-no-params.js
@@ -1,0 +1,13 @@
+const xhr = new XMLHttpRequest();
+xhr.withCredentials = true;
+
+xhr.addEventListener("readystatechange", function () {
+  if (this.readyState === this.DONE) {
+    console.log(this.responseText);
+  }
+});
+
+xhr.open("POST", "https://httpbin.org/anything");
+xhr.setRequestHeader("Content-Type", "multipart/form-data");
+
+xhr.send(data);

--- a/__tests__/__fixtures__/output/kotlin/okhttp/multipart-form-data-no-params.kt
+++ b/__tests__/__fixtures__/output/kotlin/okhttp/multipart-form-data-no-params.kt
@@ -1,0 +1,9 @@
+val client = OkHttpClient()
+
+val request = Request.Builder()
+  .url("https://httpbin.org/anything")
+  .post(null)
+  .addHeader("Content-Type", "multipart/form-data")
+  .build()
+
+val response = client.newCall(request).execute()

--- a/__tests__/__fixtures__/output/node/axios/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/node/axios/multipart-form-data-no-params.js
@@ -1,0 +1,13 @@
+const axios = require("axios").default;
+
+const options = {
+  method: 'POST',
+  url: 'https://httpbin.org/anything',
+  headers: {'Content-Type': 'multipart/form-data'}
+};
+
+axios.request(options).then(function (response) {
+  console.log(response.data);
+}).catch(function (error) {
+  console.error(error);
+});

--- a/__tests__/__fixtures__/output/node/fetch/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/node/fetch/multipart-form-data-no-params.js
@@ -1,0 +1,9 @@
+const fetch = require('node-fetch');
+
+const url = 'https://httpbin.org/anything';
+const options = {method: 'POST', headers: {'Content-Type': 'multipart/form-data'}};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));

--- a/__tests__/__fixtures__/output/node/native/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/node/native/multipart-form-data-no-params.js
@@ -1,0 +1,26 @@
+const http = require("https");
+
+const options = {
+  "method": "POST",
+  "hostname": "httpbin.org",
+  "port": null,
+  "path": "/anything",
+  "headers": {
+    "Content-Type": "multipart/form-data"
+  }
+};
+
+const req = http.request(options, function (res) {
+  const chunks = [];
+
+  res.on("data", function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on("end", function () {
+    const body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.end();

--- a/__tests__/__fixtures__/output/node/request/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/node/request/multipart-form-data-no-params.js
@@ -1,0 +1,14 @@
+const request = require('request');
+
+const options = {
+  method: 'POST',
+  url: 'https://httpbin.org/anything',
+  headers: {'Content-Type': 'multipart/form-data'}
+};
+
+request(options, function (error, response, body) {
+  if (error) throw new Error(error);
+
+  console.log(body);
+});
+

--- a/__tests__/__fixtures__/output/node/unirest/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/output/node/unirest/multipart-form-data-no-params.js
@@ -1,0 +1,14 @@
+const unirest = require("unirest");
+
+const req = unirest("POST", "https://httpbin.org/anything");
+
+req.headers({
+  "Content-Type": "multipart/form-data"
+});
+
+req.end(function (res) {
+  if (res.error) throw new Error(res.error);
+
+  console.log(res.body);
+});
+

--- a/__tests__/__fixtures__/output/objc/nsurlsession/multipart-form-data-no-params.m
+++ b/__tests__/__fixtures__/output/objc/nsurlsession/multipart-form-data-no-params.m
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+NSDictionary *headers = @{ @"Content-Type": @"multipart/form-data" };
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://httpbin.org/anything"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"POST"];
+[request setAllHTTPHeaderFields:headers];
+
+NSURLSession *session = [NSURLSession sharedSession];
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                                if (error) {
+                                                    NSLog(@"%@", error);
+                                                } else {
+                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+                                                    NSLog(@"%@", httpResponse);
+                                                }
+                                            }];
+[dataTask resume];

--- a/__tests__/__fixtures__/output/ocaml/cohttp/multipart-form-data-no-params.ml
+++ b/__tests__/__fixtures__/output/ocaml/cohttp/multipart-form-data-no-params.ml
@@ -1,0 +1,10 @@
+open Cohttp_lwt_unix
+open Cohttp
+open Lwt
+
+let uri = Uri.of_string "https://httpbin.org/anything" in
+let headers = Header.add (Header.init ()) "Content-Type" "multipart/form-data" in
+
+Client.call ~headers `POST uri
+>>= fun (res, body_stream) ->
+  (* Do stuff with the result *)

--- a/__tests__/__fixtures__/output/php/curl/multipart-form-data-no-params.php
+++ b/__tests__/__fixtures__/output/php/curl/multipart-form-data-no-params.php
@@ -1,0 +1,28 @@
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, [
+  CURLOPT_URL => "https://httpbin.org/anything",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => "",
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 30,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => "POST",
+  CURLOPT_POSTFIELDS => "",
+  CURLOPT_HTTPHEADER => [
+    "Content-Type: multipart/form-data"
+  ],
+]);
+
+$response = curl_exec($curl);
+$err = curl_error($curl);
+
+curl_close($curl);
+
+if ($err) {
+  echo "cURL Error #:" . $err;
+} else {
+  echo $response;
+}

--- a/__tests__/__fixtures__/output/php/guzzle/multipart-form-data-no-params.php
+++ b/__tests__/__fixtures__/output/php/guzzle/multipart-form-data-no-params.php
@@ -1,0 +1,12 @@
+<?php
+require_once('vendor/autoload.php');
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'https://httpbin.org/anything', [
+  'headers' => [
+    'Content-Type' => 'multipart/form-data',
+  ],
+]);
+
+echo $response->getBody();

--- a/__tests__/__fixtures__/output/php/http1/multipart-form-data-no-params.php
+++ b/__tests__/__fixtures__/output/php/http1/multipart-form-data-no-params.php
@@ -1,0 +1,17 @@
+<?php
+
+$request = new HttpRequest();
+$request->setUrl('https://httpbin.org/anything');
+$request->setMethod(HTTP_METH_POST);
+
+$request->setHeaders([
+  'Content-Type' => 'multipart/form-data'
+]);
+
+try {
+  $response = $request->send();
+
+  echo $response->getBody();
+} catch (HttpException $ex) {
+  echo $ex;
+}

--- a/__tests__/__fixtures__/output/php/http2/multipart-form-data-no-params.php
+++ b/__tests__/__fixtures__/output/php/http2/multipart-form-data-no-params.php
@@ -1,0 +1,15 @@
+<?php
+
+$client = new http\Client;
+$request = new http\Client\Request;
+
+$request->setRequestUrl('https://httpbin.org/anything');
+$request->setRequestMethod('POST');
+$request->setHeaders([
+  'Content-Type' => 'multipart/form-data'
+]);
+
+$client->enqueue($request)->send();
+$response = $client->getResponse();
+
+echo $response->getBody();

--- a/__tests__/__fixtures__/output/powershell/restmethod/multipart-form-data-no-params.ps1
+++ b/__tests__/__fixtures__/output/powershell/restmethod/multipart-form-data-no-params.ps1
@@ -1,0 +1,3 @@
+$headers=@{}
+$headers.Add("Content-Type", "multipart/form-data")
+$response = Invoke-RestMethod -Uri 'https://httpbin.org/anything' -Method POST -Headers $headers

--- a/__tests__/__fixtures__/output/powershell/webrequest/multipart-form-data-no-params.ps1
+++ b/__tests__/__fixtures__/output/powershell/webrequest/multipart-form-data-no-params.ps1
@@ -1,0 +1,3 @@
+$headers=@{}
+$headers.Add("Content-Type", "multipart/form-data")
+$response = Invoke-WebRequest -Uri 'https://httpbin.org/anything' -Method POST -Headers $headers

--- a/__tests__/__fixtures__/output/python/python3/multipart-form-data-no-params.py
+++ b/__tests__/__fixtures__/output/python/python3/multipart-form-data-no-params.py
@@ -1,0 +1,14 @@
+import http.client
+
+conn = http.client.HTTPSConnection("httpbin.org")
+
+payload = ""
+
+headers = { 'Content-Type': "multipart/form-data" }
+
+conn.request("POST", "/anything", payload, headers)
+
+res = conn.getresponse()
+data = res.read()
+
+print(data.decode("utf-8"))

--- a/__tests__/__fixtures__/output/python/requests/multipart-form-data-no-params.py
+++ b/__tests__/__fixtures__/output/python/requests/multipart-form-data-no-params.py
@@ -1,0 +1,10 @@
+import requests
+
+url = "https://httpbin.org/anything"
+
+payload = ""
+headers = {"Content-Type": "multipart/form-data"}
+
+response = requests.request("POST", url, data=payload, headers=headers)
+
+print(response.text)

--- a/__tests__/__fixtures__/output/r/httr/multipart-form-data-no-params.r
+++ b/__tests__/__fixtures__/output/r/httr/multipart-form-data-no-params.r
@@ -1,0 +1,9 @@
+library(httr)
+
+url <- "https://httpbin.org/anything"
+
+payload <- ""
+
+response <- VERB("POST", url, body = payload, content_type("multipart/form-data"))
+
+content(response, "text")

--- a/__tests__/__fixtures__/output/ruby/native/multipart-form-data-no-params.rb
+++ b/__tests__/__fixtures__/output/ruby/native/multipart-form-data-no-params.rb
@@ -1,0 +1,14 @@
+require 'uri'
+require 'net/http'
+require 'openssl'
+
+url = URI("https://httpbin.org/anything")
+
+http = Net::HTTP.new(url.host, url.port)
+http.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["Content-Type"] = 'multipart/form-data'
+
+response = http.request(request)
+puts response.read_body

--- a/__tests__/__fixtures__/output/shell/curl/multipart-form-data-no-params.sh
+++ b/__tests__/__fixtures__/output/shell/curl/multipart-form-data-no-params.sh
@@ -1,0 +1,3 @@
+curl --request POST \
+  --url https://httpbin.org/anything \
+  --header 'Content-Type: multipart/form-data'

--- a/__tests__/__fixtures__/output/shell/httpie/multipart-form-data-no-params.sh
+++ b/__tests__/__fixtures__/output/shell/httpie/multipart-form-data-no-params.sh
@@ -1,0 +1,2 @@
+http POST https://httpbin.org/anything \
+  Content-Type:multipart/form-data

--- a/__tests__/__fixtures__/output/shell/wget/multipart-form-data-no-params.sh
+++ b/__tests__/__fixtures__/output/shell/wget/multipart-form-data-no-params.sh
@@ -1,0 +1,5 @@
+wget --quiet \
+  --method POST \
+  --header 'Content-Type: multipart/form-data' \
+  --output-document \
+  - https://httpbin.org/anything

--- a/__tests__/__fixtures__/output/swift/nsurlsession/multipart-form-data-no-params.swift
+++ b/__tests__/__fixtures__/output/swift/nsurlsession/multipart-form-data-no-params.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+let headers = ["Content-Type": "multipart/form-data"]
+
+let request = NSMutableURLRequest(url: NSURL(string: "https://httpbin.org/anything")! as URL,
+                                        cachePolicy: .useProtocolCachePolicy,
+                                    timeoutInterval: 10.0)
+request.httpMethod = "POST"
+request.allHTTPHeaderFields = headers
+
+let session = URLSession.shared
+let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
+  if (error != nil) {
+    print(error)
+  } else {
+    let httpResponse = response as? HTTPURLResponse
+    print(httpResponse)
+  }
+})
+
+dataTask.resume()

--- a/__tests__/__fixtures__/requests/multipart-form-data-no-params.js
+++ b/__tests__/__fixtures__/requests/multipart-form-data-no-params.js
@@ -1,0 +1,55 @@
+module.exports = {
+  log: {
+    version: '1.2',
+    creator: {
+      name: 'HTTPSnippet',
+      version: '1.0.0',
+    },
+    entries: [
+      {
+        request: {
+          method: 'POST',
+          url: 'https://httpbin.org/anything',
+          headers: [
+            {
+              name: 'Content-Type',
+              value: 'multipart/form-data',
+            },
+          ],
+          postData: {
+            mimeType: 'multipart/form-data',
+          },
+        },
+        response: {
+          status: 200,
+          statusText: 'OK',
+          httpVersion: 'HTTP/1.1',
+          headers: [
+            {
+              name: 'Content-Type',
+              value: 'application/json',
+            },
+          ],
+          content: {
+            size: -1,
+            mimeType: 'application/json',
+            text: JSON.stringify({
+              args: {},
+              data: '',
+              files: {},
+              form: {},
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+              json: null,
+              method: 'POST',
+              url: 'https://httpbin.org/anything',
+            }),
+          },
+          headersSize: -1,
+          bodySize: -1,
+        },
+      },
+    ],
+  },
+};

--- a/integrations/php.Dockerfile
+++ b/integrations/php.Dockerfile
@@ -10,7 +10,7 @@ ADD . /src
 WORKDIR /src
 
 RUN apk update
-RUN apk add php8 php8-fpm php87-opcache php8-curl
+RUN apk add php8 php8-fpm php8-opcache php8-curl
 RUN apk add --update nodejs npm
 RUN npm install
 

--- a/integrations/php.Dockerfile
+++ b/integrations/php.Dockerfile
@@ -10,7 +10,7 @@ ADD . /src
 WORKDIR /src
 
 RUN apk update
-RUN apk add php7 php7-fpm php7-opcache php7-curl
+RUN apk add php8 php8-fpm php87-opcache php8-curl
 RUN apk add --update nodejs npm
 RUN npm install
 

--- a/integrations/php.Dockerfile
+++ b/integrations/php.Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /src
 RUN apk update
 RUN apk add php8 php8-fpm php8-opcache php8-curl
 RUN apk add --update nodejs npm
+RUN ln /usr/bin/php8 /usr/bin/php
 RUN npm install
 
 COPY --from=builder /composer/vendor /src/vendor

--- a/src/targets/clojure/clj_http.js
+++ b/src/targets/clojure/clj_http.js
@@ -128,20 +128,22 @@ module.exports = function (source, options) {
       delete params.headers[helpers.getHeaderName(params.headers, 'content-type')];
       break;
     case 'multipart/form-data':
-      params.multipart = source.postData.params.map(function (x) {
-        if (x.fileName && !x.value) {
+      if (source.postData.params) {
+        params.multipart = source.postData.params.map(function (x) {
+          if (x.fileName && !x.value) {
+            return {
+              name: x.name,
+              content: new File(x.fileName),
+            };
+          }
+
           return {
             name: x.name,
-            content: new File(x.fileName),
+            content: x.value,
           };
-        }
-
-        return {
-          name: x.name,
-          content: x.value,
-        };
-      });
-      delete params.headers[helpers.getHeaderName(params.headers, 'content-type')];
+        });
+        delete params.headers[helpers.getHeaderName(params.headers, 'content-type')];
+      }
       break;
   }
 

--- a/src/targets/javascript/axios.js
+++ b/src/targets/javascript/axios.js
@@ -46,19 +46,21 @@ module.exports = function (source, options) {
       break;
 
     case 'multipart/form-data':
-      code.push('const form = new FormData();');
+      if (source.postData.params) {
+        code.push('const form = new FormData();');
 
-      source.postData.params.forEach(function (param) {
-        code.push(
-          'form.append(%s, %s);',
-          JSON.stringify(param.name),
-          JSON.stringify(param.value || param.fileName || '')
-        );
-      });
+        source.postData.params.forEach(function (param) {
+          code.push(
+            'form.append(%s, %s);',
+            JSON.stringify(param.name),
+            JSON.stringify(param.value || param.fileName || '')
+          );
+        });
 
-      code.blank();
+        code.blank();
 
-      reqOpts.data = '[form]';
+        reqOpts.data = '[form]';
+      }
       break;
 
     default:

--- a/src/targets/javascript/fetch.js
+++ b/src/targets/javascript/fetch.js
@@ -44,17 +44,19 @@ module.exports = function (source, options) {
       break;
 
     case 'multipart/form-data':
-      code.push('const form = new FormData();');
+      if (source.postData.params) {
+        code.push('const form = new FormData();');
 
-      source.postData.params.forEach(function (param) {
-        code.push(
-          'form.append(%s, %s);',
-          JSON.stringify(param.name),
-          JSON.stringify(param.value || param.fileName || '')
-        );
-      });
+        source.postData.params.forEach(function (param) {
+          code.push(
+            'form.append(%s, %s);',
+            JSON.stringify(param.name),
+            JSON.stringify(param.value || param.fileName || '')
+          );
+        });
 
-      code.blank();
+        code.blank();
+      }
       break;
 
     default:
@@ -89,7 +91,9 @@ module.exports = function (source, options) {
     .blank();
 
   if (source.postData.mimeType === 'multipart/form-data') {
-    code.push('options.body = form;').blank();
+    if (source.postData.params) {
+      code.push('options.body = form;').blank();
+    }
   }
 
   code

--- a/src/targets/javascript/jquery.js
+++ b/src/targets/javascript/jquery.js
@@ -38,29 +38,31 @@ module.exports = function (source, options) {
       break;
 
     case 'multipart/form-data':
-      code.push('const form = new FormData();');
+      if (source.postData.params) {
+        code.push('const form = new FormData();');
 
-      source.postData.params.forEach(function (param) {
-        code.push(
-          'form.append(%s, %s);',
-          JSON.stringify(param.name),
-          JSON.stringify(param.value || param.fileName || '')
-        );
-      });
+        source.postData.params.forEach(function (param) {
+          code.push(
+            'form.append(%s, %s);',
+            JSON.stringify(param.name),
+            JSON.stringify(param.value || param.fileName || '')
+          );
+        });
 
-      settings.processData = false;
-      settings.contentType = false;
-      settings.mimeType = 'multipart/form-data';
-      settings.data = '[form]';
+        settings.processData = false;
+        settings.contentType = false;
+        settings.mimeType = 'multipart/form-data';
+        settings.data = '[form]';
 
-      // remove the contentType header
-      if (helpers.hasHeader(settings.headers, 'content-type')) {
-        if (helpers.getHeader(settings.headers, 'content-type').indexOf('boundary')) {
-          delete settings.headers[helpers.getHeaderName(settings.headers, 'content-type')];
+        // remove the contentType header
+        if (helpers.hasHeader(settings.headers, 'content-type')) {
+          if (helpers.getHeader(settings.headers, 'content-type').indexOf('boundary')) {
+            delete settings.headers[helpers.getHeaderName(settings.headers, 'content-type')];
+          }
         }
-      }
 
-      code.blank();
+        code.blank();
+      }
       break;
 
     default:

--- a/src/targets/javascript/xhr.js
+++ b/src/targets/javascript/xhr.js
@@ -26,25 +26,27 @@ module.exports = function (source, options) {
       break;
 
     case 'multipart/form-data':
-      code.push('const data = new FormData();');
+      if (source.postData.params) {
+        code.push('const data = new FormData();');
 
-      source.postData.params.forEach(function (param) {
-        code.push(
-          'data.append(%s, %s);',
-          JSON.stringify(param.name),
-          JSON.stringify(param.value || param.fileName || '')
-        );
-      });
+        source.postData.params.forEach(function (param) {
+          code.push(
+            'data.append(%s, %s);',
+            JSON.stringify(param.name),
+            JSON.stringify(param.value || param.fileName || '')
+          );
+        });
 
-      // remove the contentType header
-      if (helpers.hasHeader(source.allHeaders, 'content-type')) {
-        if (helpers.getHeader(source.allHeaders, 'content-type').indexOf('boundary')) {
-          // eslint-disable-next-line no-param-reassign
-          delete source.allHeaders[helpers.getHeaderName(source.allHeaders, 'content-type')];
+        // remove the contentType header
+        if (helpers.hasHeader(source.allHeaders, 'content-type')) {
+          if (helpers.getHeader(source.allHeaders, 'content-type').indexOf('boundary')) {
+            // eslint-disable-next-line no-param-reassign
+            delete source.allHeaders[helpers.getHeaderName(source.allHeaders, 'content-type')];
+          }
         }
-      }
 
-      code.blank();
+        code.blank();
+      }
       break;
 
     default:

--- a/src/targets/node/request.js
+++ b/src/targets/node/request.js
@@ -44,33 +44,35 @@ module.exports = function (source, options) {
       break;
 
     case 'multipart/form-data':
-      reqOpts.formData = {};
+      if (source.postData.params) {
+        reqOpts.formData = {};
 
-      source.postData.params.forEach(function (param) {
-        const attachment = {};
+        source.postData.params.forEach(function (param) {
+          const attachment = {};
 
-        if (!param.fileName && !param.contentType) {
-          reqOpts.formData[param.name] = param.value;
-          return;
-        }
+          if (!param.fileName && !param.contentType) {
+            reqOpts.formData[param.name] = param.value;
+            return;
+          }
 
-        if (param.fileName) {
-          includeFS = true;
+          if (param.fileName) {
+            includeFS = true;
 
-          attachment.value = `fs.createReadStream("${param.fileName}")`;
-        } else if (param.value) {
-          attachment.value = param.value;
-        }
+            attachment.value = `fs.createReadStream("${param.fileName}")`;
+          } else if (param.value) {
+            attachment.value = param.value;
+          }
 
-        if (param.fileName) {
-          attachment.options = {
-            filename: param.fileName,
-            contentType: param.contentType ? param.contentType : null,
-          };
-        }
+          if (param.fileName) {
+            attachment.options = {
+              filename: param.fileName,
+              contentType: param.contentType ? param.contentType : null,
+            };
+          }
 
-        reqOpts.formData[param.name] = attachment;
-      });
+          reqOpts.formData[param.name] = attachment;
+        });
+      }
       break;
 
     default:

--- a/src/targets/node/unirest.js
+++ b/src/targets/node/unirest.js
@@ -63,29 +63,31 @@ module.exports = function (source, options) {
       break;
 
     case 'multipart/form-data': {
-      const multipart = [];
+      if (source.postData.params) {
+        const multipart = [];
 
-      source.postData.params.forEach(function (param) {
-        const part = {};
+        source.postData.params.forEach(function (param) {
+          const part = {};
 
-        if (param.fileName && !param.value) {
-          includeFS = true;
+          if (param.fileName && !param.value) {
+            includeFS = true;
 
-          part.body = `fs.createReadStream("${param.fileName}")`;
-        } else if (param.value) {
-          part.body = param.value;
-        }
-
-        if (part.body) {
-          if (param.contentType) {
-            part['content-type'] = param.contentType;
+            part.body = `fs.createReadStream("${param.fileName}")`;
+          } else if (param.value) {
+            part.body = param.value;
           }
 
-          multipart.push(part);
-        }
-      });
+          if (part.body) {
+            if (param.contentType) {
+              part['content-type'] = param.contentType;
+            }
 
-      code.push('req.multipart(%s);', JSON.stringify(multipart, null, opts.indent)).blank();
+            multipart.push(part);
+          }
+        });
+
+        code.push('req.multipart(%s);', JSON.stringify(multipart, null, opts.indent)).blank();
+      }
       break;
     }
 

--- a/src/targets/shell/curl.js
+++ b/src/targets/shell/curl.js
@@ -75,16 +75,18 @@ module.exports = function (source, options) {
   // construct post params
   switch (source.postData.mimeType) {
     case 'multipart/form-data':
-      source.postData.params.forEach(function (param) {
-        let post = '';
-        if (param.fileName) {
-          post = format('%s=@%s', param.name, param.fileName);
-        } else {
-          post = format('%s=%s', param.name, param.value);
-        }
+      if (source.postData.params) {
+        source.postData.params.forEach(function (param) {
+          let post = '';
+          if (param.fileName) {
+            post = format('%s=@%s', param.name, param.fileName);
+          } else {
+            post = format('%s=%s', param.name, param.value);
+          }
 
-        code.push('%s %s', opts.short ? '-F' : '--form', helpers.quote(post));
-      });
+          code.push('%s %s', opts.short ? '-F' : '--form', helpers.quote(post));
+        });
+      }
       break;
 
     case 'application/x-www-form-urlencoded':


### PR DESCRIPTION
## 🧰 What's being changed?

A number of targets made the assumption that if you're doing a `multipart/form-data` request that you'd have `postData.params` present, and when that isn't true they'd crash. Now normally you would have parameters present for a request like this but the [HAR spec](http://www.softwareishard.com/blog/har-12-spec/#request) specifies that `postData.params` is optional so these targets should respect that. 

## 🧬 Testing

* [ ] Do all tests pass?
* [ ] Does the integration suite pass?
* [ ] These new code snippets look ok?