### PR TITLE
feat: cleaner python requests code by using available http accessors

### DIFF
--- a/__tests__/__fixtures__/output/python/requests/application-form-encoded.py
+++ b/__tests__/__fixtures__/output/python/requests/application-form-encoded.py
@@ -5,6 +5,6 @@ url = "https://httpbin.org/anything"
 payload = "foo=bar&hello=world"
 headers = {"content-type": "application/x-www-form-urlencoded"}
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/application-json.py
+++ b/__tests__/__fixtures__/output/python/requests/application-json.py
@@ -12,6 +12,6 @@ payload = {
 }
 headers = {"content-type": "application/json"}
 
-response = requests.request("POST", url, json=payload, headers=headers)
+response = requests.post(url, json=payload, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/cookies.py
+++ b/__tests__/__fixtures__/output/python/requests/cookies.py
@@ -4,6 +4,6 @@ url = "https://httpbin.org/cookies"
 
 headers = {"cookie": "foo=bar; bar=baz"}
 
-response = requests.request("GET", url, headers=headers)
+response = requests.get(url, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/full.py
+++ b/__tests__/__fixtures__/output/python/requests/full.py
@@ -9,6 +9,6 @@ headers = {
     "content-type": "application/x-www-form-urlencoded"
 }
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/headers.py
+++ b/__tests__/__fixtures__/output/python/requests/headers.py
@@ -7,6 +7,6 @@ headers = {
     "x-foo": "Bar"
 }
 
-response = requests.request("GET", url, headers=headers)
+response = requests.get(url, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/http-insecure.py
+++ b/__tests__/__fixtures__/output/python/requests/http-insecure.py
@@ -2,6 +2,6 @@ import requests
 
 url = "http://httpbin.org/anything"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/jsonObj-multiline.py
+++ b/__tests__/__fixtures__/output/python/requests/jsonObj-multiline.py
@@ -5,6 +5,6 @@ url = "https://httpbin.org/anything"
 payload = {"foo": "bar"}
 headers = {"content-type": "application/json"}
 
-response = requests.request("POST", url, json=payload, headers=headers)
+response = requests.post(url, json=payload, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/jsonObj-null-value.py
+++ b/__tests__/__fixtures__/output/python/requests/jsonObj-null-value.py
@@ -5,6 +5,6 @@ url = "https://httpbin.org/anything"
 payload = {"foo": None}
 headers = {"content-type": "application/json"}
 
-response = requests.request("POST", url, json=payload, headers=headers)
+response = requests.post(url, json=payload, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/multipart-data.py
+++ b/__tests__/__fixtures__/output/python/requests/multipart-data.py
@@ -5,6 +5,6 @@ url = "https://httpbin.org/anything"
 files = {"foo": open("__tests__/__fixtures__/files/hello.txt", "rb")}
 payload = {"bar": "Bonjour le monde"}
 
-response = requests.request("POST", url, data=payload, files=files)
+response = requests.post(url, data=payload, files=files)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/multipart-file.py
+++ b/__tests__/__fixtures__/output/python/requests/multipart-file.py
@@ -4,6 +4,6 @@ url = "https://httpbin.org/anything"
 
 files = {"foo": open("__tests__/__fixtures__/files/hello.txt", "rb")}
 
-response = requests.request("POST", url, files=files)
+response = requests.post(url, files=files)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/multipart-form-data-no-params.py
+++ b/__tests__/__fixtures__/output/python/requests/multipart-form-data-no-params.py
@@ -4,6 +4,6 @@ url = "https://httpbin.org/anything"
 
 headers = {"Content-Type": "multipart/form-data"}
 
-response = requests.request("POST", url, headers=headers)
+response = requests.post(url, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/multipart-form-data.py
+++ b/__tests__/__fixtures__/output/python/requests/multipart-form-data.py
@@ -5,6 +5,6 @@ url = "https://httpbin.org/anything"
 payload = "-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n-----011000010111000001101001--\r\n"
 headers = {"Content-Type": "multipart/form-data; boundary=---011000010111000001101001"}
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/nested.py
+++ b/__tests__/__fixtures__/output/python/requests/nested.py
@@ -2,6 +2,6 @@ import requests
 
 url = "https://httpbin.org/anything?foo%5Bbar%5D=baz%2Czap&fiz=buz&key=value"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/query-encoded.py
+++ b/__tests__/__fixtures__/output/python/requests/query-encoded.py
@@ -2,6 +2,6 @@ import requests
 
 url = "https://httpbin.org/anything?startTime=2019-06-13T19%3A08%3A25.455Z&endTime=2015-09-15T14%3A00%3A12-04%3A00"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/query.py
+++ b/__tests__/__fixtures__/output/python/requests/query.py
@@ -2,6 +2,6 @@ import requests
 
 url = "https://httpbin.org/anything?foo=bar&foo=baz&baz=abc&key=value"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/short.py
+++ b/__tests__/__fixtures__/output/python/requests/short.py
@@ -2,6 +2,6 @@ import requests
 
 url = "https://httpbin.org/anything"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)

--- a/__tests__/__fixtures__/output/python/requests/text-plain.py
+++ b/__tests__/__fixtures__/output/python/requests/text-plain.py
@@ -5,6 +5,6 @@ url = "https://httpbin.org/anything"
 payload = "Hello World"
 headers = {"content-type": "text/plain"}
 
-response = requests.request("POST", url, data=payload, headers=headers)
+response = requests.post(url, data=payload, headers=headers)
 
 print(response.text)

--- a/__tests__/targets/python/requests.js
+++ b/__tests__/targets/python/requests.js
@@ -11,7 +11,7 @@ module.exports = function (HTTPSnippet) {
 
 url = "https://httpbin.org/anything?param=value"
 
-response = requests.request("GET", url)
+response = requests.get(url)
 
 print(response.text)`);
   });

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -119,7 +119,12 @@ module.exports = function (source, options) {
 
   // Construct request
   const method = source.method;
-  let request = format('response = requests.request("%s", url', method);
+  let request;
+  if (['HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+    request = format('response = requests.%s(url', method.toLowerCase());
+  } else {
+    request = format('response = requests.request("%s", url', method);
+  }
 
   if (hasPayload) {
     if (jsonPayload) {

--- a/src/targets/python/requests.js
+++ b/src/targets/python/requests.js
@@ -120,6 +120,7 @@ module.exports = function (source, options) {
   // Construct request
   const method = source.method;
   let request;
+  // Method list pulled from their api reference https://docs.python-requests.org/en/latest/api/#requests.head
   if (['HEAD', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
     request = format('response = requests.%s(url', method.toLowerCase());
   } else {


### PR DESCRIPTION
## 🧰 What's being changed?

Cleans up the Python [requests](https://docs.python-requests.org/en/latest/) library snippets by utilizing the HTTP method accessors they provide.

**Before:**

```py
response = requests.request("POST", url, data=payload, headers=headers)
```

**After:**

```py
response = requests.post(url, data=payload, headers=headers)
```

## 🧬 Testing

No testing needed if CI is all ✅