### PR TITLE
fix: js + axios snippets for `x-www-form-urlencoded` are wrong

### DIFF
--- a/__tests__/__fixtures__/output/javascript/axios/application-form-encoded.js
+++ b/__tests__/__fixtures__/output/javascript/axios/application-form-encoded.js
@@ -1,10 +1,14 @@
 import axios from "axios";
 
+const encodedParams = new URLSearchParams();
+encodedParams.set('foo', 'bar');
+encodedParams.set('hello', 'world');
+
 const options = {
   method: 'POST',
   url: 'https://httpbin.org/anything',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  data: {foo: 'bar', hello: 'world'}
+  data: encodedParams,
 };
 
 axios.request(options).then(function (response) {

--- a/__tests__/__fixtures__/output/javascript/axios/full.js
+++ b/__tests__/__fixtures__/output/javascript/axios/full.js
@@ -1,5 +1,8 @@
 import axios from "axios";
 
+const encodedParams = new URLSearchParams();
+encodedParams.set('foo', 'bar');
+
 const options = {
   method: 'POST',
   url: 'https://httpbin.org/anything',
@@ -9,7 +12,7 @@ const options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  data: {foo: 'bar'}
+  data: encodedParams,
 };
 
 axios.request(options).then(function (response) {

--- a/__tests__/__fixtures__/output/node/axios/application-form-encoded.js
+++ b/__tests__/__fixtures__/output/node/axios/application-form-encoded.js
@@ -1,7 +1,7 @@
 const axios = require("axios").default;
 const { URLSearchParams } = require('url');
-const encodedParams = new URLSearchParams();
 
+const encodedParams = new URLSearchParams();
 encodedParams.set('foo', 'bar');
 encodedParams.set('hello', 'world');
 
@@ -9,7 +9,7 @@ const options = {
   method: 'POST',
   url: 'https://httpbin.org/anything',
   headers: {'content-type': 'application/x-www-form-urlencoded'},
-  data: encodedParams
+  data: encodedParams,
 };
 
 axios.request(options).then(function (response) {

--- a/__tests__/__fixtures__/output/node/axios/full.js
+++ b/__tests__/__fixtures__/output/node/axios/full.js
@@ -1,7 +1,7 @@
 const axios = require("axios").default;
 const { URLSearchParams } = require('url');
-const encodedParams = new URLSearchParams();
 
+const encodedParams = new URLSearchParams();
 encodedParams.set('foo', 'bar');
 
 const options = {
@@ -12,7 +12,7 @@ const options = {
     accept: 'application/json',
     'content-type': 'application/x-www-form-urlencoded'
   },
-  data: encodedParams
+  data: encodedParams,
 };
 
 axios.request(options).then(function (response) {

--- a/src/targets/javascript/axios.js
+++ b/src/targets/javascript/axios.js
@@ -36,7 +36,14 @@ module.exports = function (source, options) {
 
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
-      reqOpts.data = source.postData.paramsObj;
+      code.push('const encodedParams = new URLSearchParams();');
+      source.postData.params.forEach(function (param) {
+        code.push(`encodedParams.set('${param.name}', '${param.value}');`);
+      });
+
+      code.blank();
+
+      reqOpts.data = 'encodedParams';
       break;
 
     case 'application/json':
@@ -83,7 +90,7 @@ module.exports = function (source, options) {
     .push(1, 'console.error(error);')
     .push('});');
 
-  return code.join();
+  return code.join().replace(/'encodedParams'/, 'encodedParams,');
 };
 
 module.exports.info = {

--- a/src/targets/node/axios.js
+++ b/src/targets/node/axios.js
@@ -33,9 +33,9 @@ module.exports = function (source, options) {
   switch (source.postData.mimeType) {
     case 'application/x-www-form-urlencoded':
       code.push("const { URLSearchParams } = require('url');");
-      code.push('const encodedParams = new URLSearchParams();');
       code.blank();
 
+      code.push('const encodedParams = new URLSearchParams();');
       source.postData.params.forEach(function (param) {
         code.push(`encodedParams.set('${param.name}', '${param.value}');`);
       });
@@ -65,7 +65,7 @@ module.exports = function (source, options) {
     .push(1, 'console.error(error);')
     .push('});');
 
-  return code.join().replace(/'encodedParams'/, 'encodedParams');
+  return code.join().replace(/'encodedParams'/, 'encodedParams,');
 };
 
 module.exports.info = {


### PR DESCRIPTION
| 🚥 Fix https://github.com/readmeio/api/issues/436 |
| :-- |

## 🧰 Changes

This updates the snippets that we generate for [Axios](https://npm.im/axios) on JS to properly send payloads for `x-www-form-urlencoded` requests.

I'm also updating the Node Axios snippets to have some breathing room where we set up `URLSearchParams` and to also have a consistent trailing comma where it's applied to the payload.

## 🧬 QA & Testing

See tests.