### PR TITLE
fix: headers not being properly applied to R httr snippets

### DIFF
--- a/__tests__/__fixtures__/output/c/libcurl/headers.c
+++ b/__tests__/__fixtures__/output/c/libcurl/headers.c
@@ -6,6 +6,7 @@ curl_easy_setopt(hnd, CURLOPT_URL, "https://httpbin.org/headers");
 struct curl_slist *headers = NULL;
 headers = curl_slist_append(headers, "accept: text/json");
 headers = curl_slist_append(headers, "x-foo: Bar");
+headers = curl_slist_append(headers, "x-bar: Foo");
 curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
 
 CURLcode ret = curl_easy_perform(hnd);

--- a/__tests__/__fixtures__/output/clojure/clj_http/headers.clj
+++ b/__tests__/__fixtures__/output/clojure/clj_http/headers.clj
@@ -1,4 +1,5 @@
 (require '[clj-http.client :as client])
 
 (client/get "https://httpbin.org/headers" {:headers {:accept "text/json"
-                                                     :x-foo "Bar"}})
+                                                     :x-foo "Bar"
+                                                     :x-bar "Foo"}})

--- a/__tests__/__fixtures__/output/csharp/httpclient/headers.cs
+++ b/__tests__/__fixtures__/output/csharp/httpclient/headers.cs
@@ -7,6 +7,7 @@ var request = new HttpRequestMessage
     {
         { "accept", "text/json" },
         { "x-foo", "Bar" },
+        { "x-bar", "Foo" },
     },
 };
 using (var response = await client.SendAsync(request))

--- a/__tests__/__fixtures__/output/csharp/restsharp/headers.cs
+++ b/__tests__/__fixtures__/output/csharp/restsharp/headers.cs
@@ -2,4 +2,5 @@ var client = new RestClient("https://httpbin.org/headers");
 var request = new RestRequest(Method.GET);
 request.AddHeader("accept", "text/json");
 request.AddHeader("x-foo", "Bar");
+request.AddHeader("x-bar", "Foo");
 IRestResponse response = client.Execute(request);

--- a/__tests__/__fixtures__/output/go/native/headers.go
+++ b/__tests__/__fixtures__/output/go/native/headers.go
@@ -14,6 +14,7 @@ func main() {
 
 	req.Header.Add("accept", "text/json")
 	req.Header.Add("x-foo", "Bar")
+	req.Header.Add("x-bar", "Foo")
 
 	res, _ := http.DefaultClient.Do(req)
 

--- a/__tests__/__fixtures__/output/http/1.1/headers
+++ b/__tests__/__fixtures__/output/http/1.1/headers
@@ -1,6 +1,7 @@
 GET /headers HTTP/1.1
 Accept: text/json
 X-Foo: Bar
+X-Bar: Foo
 Host: httpbin.org
 
 

--- a/__tests__/__fixtures__/output/java/asynchttp/headers.java
+++ b/__tests__/__fixtures__/output/java/asynchttp/headers.java
@@ -2,6 +2,7 @@ AsyncHttpClient client = new DefaultAsyncHttpClient();
 client.prepare("GET", "https://httpbin.org/headers")
   .setHeader("accept", "text/json")
   .setHeader("x-foo", "Bar")
+  .setHeader("x-bar", "Foo")
   .execute()
   .toCompletableFuture()
   .thenAccept(System.out::println)

--- a/__tests__/__fixtures__/output/java/nethttp/headers.java
+++ b/__tests__/__fixtures__/output/java/nethttp/headers.java
@@ -2,6 +2,7 @@ HttpRequest request = HttpRequest.newBuilder()
     .uri(URI.create("https://httpbin.org/headers"))
     .header("accept", "text/json")
     .header("x-foo", "Bar")
+    .header("x-bar", "Foo")
     .method("GET", HttpRequest.BodyPublishers.noBody())
     .build();
 HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());

--- a/__tests__/__fixtures__/output/java/okhttp/headers.java
+++ b/__tests__/__fixtures__/output/java/okhttp/headers.java
@@ -5,6 +5,7 @@ Request request = new Request.Builder()
   .get()
   .addHeader("accept", "text/json")
   .addHeader("x-foo", "Bar")
+  .addHeader("x-bar", "Foo")
   .build();
 
 Response response = client.newCall(request).execute();

--- a/__tests__/__fixtures__/output/java/unirest/headers.java
+++ b/__tests__/__fixtures__/output/java/unirest/headers.java
@@ -1,4 +1,5 @@
 HttpResponse<String> response = Unirest.get("https://httpbin.org/headers")
   .header("accept", "text/json")
   .header("x-foo", "Bar")
+  .header("x-bar", "Foo")
   .asString();

--- a/__tests__/__fixtures__/output/javascript/axios/headers.js
+++ b/__tests__/__fixtures__/output/javascript/axios/headers.js
@@ -3,7 +3,7 @@ import axios from "axios";
 const options = {
   method: 'GET',
   url: 'https://httpbin.org/headers',
-  headers: {accept: 'text/json', 'x-foo': 'Bar'}
+  headers: {accept: 'text/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };
 
 axios.request(options).then(function (response) {

--- a/__tests__/__fixtures__/output/javascript/fetch/headers.js
+++ b/__tests__/__fixtures__/output/javascript/fetch/headers.js
@@ -1,4 +1,4 @@
-const options = {method: 'GET', headers: {accept: 'text/json', 'x-foo': 'Bar'}};
+const options = {method: 'GET', headers: {accept: 'text/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}};
 
 fetch('https://httpbin.org/headers', options)
   .then(response => response.json())

--- a/__tests__/__fixtures__/output/javascript/jquery/headers.js
+++ b/__tests__/__fixtures__/output/javascript/jquery/headers.js
@@ -5,7 +5,8 @@ const settings = {
   "method": "GET",
   "headers": {
     "accept": "text/json",
-    "x-foo": "Bar"
+    "x-foo": "Bar",
+    "x-bar": "Foo"
   }
 };
 

--- a/__tests__/__fixtures__/output/javascript/xhr/headers.js
+++ b/__tests__/__fixtures__/output/javascript/xhr/headers.js
@@ -12,5 +12,6 @@ xhr.addEventListener("readystatechange", function () {
 xhr.open("GET", "https://httpbin.org/headers");
 xhr.setRequestHeader("accept", "text/json");
 xhr.setRequestHeader("x-foo", "Bar");
+xhr.setRequestHeader("x-bar", "Foo");
 
 xhr.send(data);

--- a/__tests__/__fixtures__/output/kotlin/okhttp/headers.kt
+++ b/__tests__/__fixtures__/output/kotlin/okhttp/headers.kt
@@ -5,6 +5,7 @@ val request = Request.Builder()
   .get()
   .addHeader("accept", "text/json")
   .addHeader("x-foo", "Bar")
+  .addHeader("x-bar", "Foo")
   .build()
 
 val response = client.newCall(request).execute()

--- a/__tests__/__fixtures__/output/node/axios/headers.js
+++ b/__tests__/__fixtures__/output/node/axios/headers.js
@@ -3,7 +3,7 @@ const axios = require("axios").default;
 const options = {
   method: 'GET',
   url: 'https://httpbin.org/headers',
-  headers: {accept: 'text/json', 'x-foo': 'Bar'}
+  headers: {accept: 'text/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };
 
 axios.request(options).then(function (response) {

--- a/__tests__/__fixtures__/output/node/fetch/headers.js
+++ b/__tests__/__fixtures__/output/node/fetch/headers.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
 
 const url = 'https://httpbin.org/headers';
-const options = {method: 'GET', headers: {accept: 'text/json', 'x-foo': 'Bar'}};
+const options = {method: 'GET', headers: {accept: 'text/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}};
 
 fetch(url, options)
   .then(res => res.json())

--- a/__tests__/__fixtures__/output/node/native/headers.js
+++ b/__tests__/__fixtures__/output/node/native/headers.js
@@ -7,7 +7,8 @@ const options = {
   "path": "/headers",
   "headers": {
     "accept": "text/json",
-    "x-foo": "Bar"
+    "x-foo": "Bar",
+    "x-bar": "Foo"
   }
 };
 

--- a/__tests__/__fixtures__/output/node/request/headers.js
+++ b/__tests__/__fixtures__/output/node/request/headers.js
@@ -3,7 +3,7 @@ const request = require('request');
 const options = {
   method: 'GET',
   url: 'https://httpbin.org/headers',
-  headers: {accept: 'text/json', 'x-foo': 'Bar'}
+  headers: {accept: 'text/json', 'x-foo': 'Bar', 'x-bar': 'Foo'}
 };
 
 request(options, function (error, response, body) {

--- a/__tests__/__fixtures__/output/node/unirest/headers.js
+++ b/__tests__/__fixtures__/output/node/unirest/headers.js
@@ -4,7 +4,8 @@ const req = unirest("GET", "https://httpbin.org/headers");
 
 req.headers({
   "accept": "text/json",
-  "x-foo": "Bar"
+  "x-foo": "Bar",
+  "x-bar": "Foo"
 });
 
 req.end(function (res) {

--- a/__tests__/__fixtures__/output/objc/nsurlsession/headers.m
+++ b/__tests__/__fixtures__/output/objc/nsurlsession/headers.m
@@ -1,7 +1,8 @@
 #import <Foundation/Foundation.h>
 
 NSDictionary *headers = @{ @"accept": @"text/json",
-                           @"x-foo": @"Bar" };
+                           @"x-foo": @"Bar",
+                           @"x-bar": @"Foo" };
 
 NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://httpbin.org/headers"]
                                                        cachePolicy:NSURLRequestUseProtocolCachePolicy

--- a/__tests__/__fixtures__/output/ocaml/cohttp/headers.ml
+++ b/__tests__/__fixtures__/output/ocaml/cohttp/headers.ml
@@ -6,6 +6,7 @@ let uri = Uri.of_string "https://httpbin.org/headers" in
 let headers = Header.add_list (Header.init ()) [
   ("accept", "text/json");
   ("x-foo", "Bar");
+  ("x-bar", "Foo");
 ] in
 
 Client.call ~headers `GET uri

--- a/__tests__/__fixtures__/output/php/curl/headers.php
+++ b/__tests__/__fixtures__/output/php/curl/headers.php
@@ -12,6 +12,7 @@ curl_setopt_array($curl, [
   CURLOPT_CUSTOMREQUEST => "GET",
   CURLOPT_HTTPHEADER => [
     "accept: text/json",
+    "x-bar: Foo",
     "x-foo: Bar"
   ],
 ]);

--- a/__tests__/__fixtures__/output/php/guzzle/headers.php
+++ b/__tests__/__fixtures__/output/php/guzzle/headers.php
@@ -6,6 +6,7 @@ $client = new \GuzzleHttp\Client();
 $response = $client->request('GET', 'https://httpbin.org/headers', [
   'headers' => [
     'accept' => 'text/json',
+    'x-bar' => 'Foo',
     'x-foo' => 'Bar',
   ],
 ]);

--- a/__tests__/__fixtures__/output/php/http1/headers.php
+++ b/__tests__/__fixtures__/output/php/http1/headers.php
@@ -6,7 +6,8 @@ $request->setMethod(HTTP_METH_GET);
 
 $request->setHeaders([
   'accept' => 'text/json',
-  'x-foo' => 'Bar'
+  'x-foo' => 'Bar',
+  'x-bar' => 'Foo'
 ]);
 
 try {

--- a/__tests__/__fixtures__/output/php/http2/headers.php
+++ b/__tests__/__fixtures__/output/php/http2/headers.php
@@ -7,7 +7,8 @@ $request->setRequestUrl('https://httpbin.org/headers');
 $request->setRequestMethod('GET');
 $request->setHeaders([
   'accept' => 'text/json',
-  'x-foo' => 'Bar'
+  'x-foo' => 'Bar',
+  'x-bar' => 'Foo'
 ]);
 
 $client->enqueue($request)->send();

--- a/__tests__/__fixtures__/output/powershell/restmethod/headers.ps1
+++ b/__tests__/__fixtures__/output/powershell/restmethod/headers.ps1
@@ -1,4 +1,5 @@
 $headers=@{}
 $headers.Add("accept", "text/json")
 $headers.Add("x-foo", "Bar")
+$headers.Add("x-bar", "Foo")
 $response = Invoke-RestMethod -Uri 'https://httpbin.org/headers' -Method GET -Headers $headers

--- a/__tests__/__fixtures__/output/powershell/webrequest/headers.ps1
+++ b/__tests__/__fixtures__/output/powershell/webrequest/headers.ps1
@@ -1,4 +1,5 @@
 $headers=@{}
 $headers.Add("accept", "text/json")
 $headers.Add("x-foo", "Bar")
+$headers.Add("x-bar", "Foo")
 $response = Invoke-WebRequest -Uri 'https://httpbin.org/headers' -Method GET -Headers $headers

--- a/__tests__/__fixtures__/output/python/requests/headers.py
+++ b/__tests__/__fixtures__/output/python/requests/headers.py
@@ -4,7 +4,8 @@ url = "https://httpbin.org/headers"
 
 headers = {
     "accept": "text/json",
-    "x-foo": "Bar"
+    "x-foo": "Bar",
+    "x-bar": "Foo"
 }
 
 response = requests.get(url, headers=headers)

--- a/__tests__/__fixtures__/output/r/httr/headers.r
+++ b/__tests__/__fixtures__/output/r/httr/headers.r
@@ -2,6 +2,6 @@ library(httr)
 
 url <- "https://httpbin.org/headers"
 
-response <- VERB("GET", url, add_headers(x_foo = 'Bar'), content_type("application/octet-stream"), accept("text/json"))
+response <- VERB("GET", url, add_headers('x-foo' = 'Bar', 'x-bar' = 'Foo'), content_type("application/octet-stream"), accept("text/json"))
 
 content(response, "text")

--- a/__tests__/__fixtures__/output/ruby/native/headers.rb
+++ b/__tests__/__fixtures__/output/ruby/native/headers.rb
@@ -10,6 +10,7 @@ http.use_ssl = true
 request = Net::HTTP::Get.new(url)
 request["accept"] = 'text/json'
 request["x-foo"] = 'Bar'
+request["x-bar"] = 'Foo'
 
 response = http.request(request)
 puts response.read_body

--- a/__tests__/__fixtures__/output/shell/curl/headers.sh
+++ b/__tests__/__fixtures__/output/shell/curl/headers.sh
@@ -1,4 +1,5 @@
 curl --request GET \
   --url https://httpbin.org/headers \
   --header 'accept: text/json' \
+  --header 'x-bar: Foo' \
   --header 'x-foo: Bar'

--- a/__tests__/__fixtures__/output/shell/httpie/headers.sh
+++ b/__tests__/__fixtures__/output/shell/httpie/headers.sh
@@ -1,3 +1,4 @@
 http GET https://httpbin.org/headers \
   accept:text/json \
+  x-bar:Foo \
   x-foo:Bar

--- a/__tests__/__fixtures__/output/shell/wget/headers.sh
+++ b/__tests__/__fixtures__/output/shell/wget/headers.sh
@@ -2,5 +2,6 @@ wget --quiet \
   --method GET \
   --header 'accept: text/json' \
   --header 'x-foo: Bar' \
+  --header 'x-bar: Foo' \
   --output-document \
   - https://httpbin.org/headers

--- a/__tests__/__fixtures__/output/swift/nsurlsession/headers.swift
+++ b/__tests__/__fixtures__/output/swift/nsurlsession/headers.swift
@@ -2,7 +2,8 @@ import Foundation
 
 let headers = [
   "accept": "text/json",
-  "x-foo": "Bar"
+  "x-foo": "Bar",
+  "x-bar": "Foo"
 ]
 
 let request = NSMutableURLRequest(url: NSURL(string: "https://httpbin.org/headers")! as URL,

--- a/__tests__/__fixtures__/requests/headers.js
+++ b/__tests__/__fixtures__/requests/headers.js
@@ -19,6 +19,10 @@ module.exports = {
               name: 'x-foo',
               value: 'Bar',
             },
+            {
+              name: 'x-bar',
+              value: 'Foo',
+            },
           ],
         },
         response: {
@@ -37,6 +41,7 @@ module.exports = {
             text: JSON.stringify({
               headers: {
                 Accept: 'text/json',
+                'X-Bar': 'Foo',
                 'X-Foo': 'Bar',
               },
             }),

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -109,6 +109,7 @@ describe('HTTPSnippet', () => {
 
     expect(req.headersObj).toStrictEqual({
       accept: 'text/json',
+      'x-bar': 'Foo',
       'x-foo': 'Bar',
     });
   });
@@ -125,6 +126,7 @@ describe('HTTPSnippet', () => {
     expect(req.headersObj).toStrictEqual({
       'Kong-Admin-Token': 'Hunter1',
       accept: 'text/json',
+      'x-bar': 'Foo',
       'x-foo': 'Bar',
     });
   });
@@ -144,6 +146,7 @@ describe('HTTPSnippet', () => {
     expect(req.headersObj).toStrictEqual({
       'kong-admin-token': 'Hunter1',
       accept: 'text/json',
+      'x-bar': 'Foo',
       'x-foo': 'Bar',
     });
   });

--- a/src/targets/r/httr.js
+++ b/src/targets/r/httr.js
@@ -75,24 +75,20 @@ module.exports = function (source) {
   }
 
   // Construct headers
-  const headers = source.allHeaders;
-  let headerCount = 0;
-  let header = '';
+  const headers = [];
   let cookies;
   let accept;
 
-  Object.keys(headers).forEach(head => {
-    if (head.toLowerCase() === 'accept') {
-      accept = `, accept("${headers[head]}")`;
-      headerCount += 1;
-    } else if (head.toLowerCase() === 'cookie') {
-      cookies = `, set_cookies(\`${headers[head].replace(/;/g, '", `').replace(/` /g, '`').replace(/=/g, '` = "')}")`;
-      headerCount += 1;
-    } else if (head.toLowerCase() !== 'content-type') {
-      header = `${header + head.replace('-', '_')} = '${headers[head]}`;
-      if (headerCount > 1) {
-        header += "', ";
-      }
+  Object.keys(source.allHeaders).forEach(header => {
+    if (header.toLowerCase() === 'accept') {
+      accept = `, accept("${source.allHeaders[header]}")`;
+    } else if (header.toLowerCase() === 'cookie') {
+      cookies = `, set_cookies(\`${source.allHeaders[header]
+        .replace(/;/g, '", `')
+        .replace(/` /g, '`')
+        .replace(/=/g, '` = "')}")`;
+    } else if (header.toLowerCase() !== 'content-type') {
+      headers.push(`'${header}' = '${source.allHeaders[header]}'`);
     }
   });
 
@@ -104,8 +100,8 @@ module.exports = function (source) {
     request += ', body = payload';
   }
 
-  if (header !== '') {
-    request += `, add_headers(${header}')`;
+  if (headers.length) {
+    request += `, add_headers(${headers.join(', ')})`;
   }
 
   if (source.queryString.length) {


### PR DESCRIPTION
| 🚥 Fix RM-4400 |
| :-- |

## 🧰 Changes

This fixes a problem with R `httr` snippets where headers are being improperly added to snippets:

```r
library(httr)

url <- "https://dash.readme.com/api/v1/api-specification"

queryString <- list(
  perPage = "10"
  page = "1",
)

response <- VERB("GET", url, add_headers(x_readme-version = 'v3.0Authorization = 'Basic REDACTED'), query = queryString, content_type("application/octet-stream"), accept("application/json"))

content(response, "text")
```

* [x] Multiple headers aren't being separated with a comma
* [x] Header values aren't always being encased with a trailing apostrophe.
* [x] `x-` headers are being rewritten to `x_`.

## 🧬 QA & Testing

I tried getting a Docker integration up and running for R but ran into a bunch of issues with getting the `httr` package installed. I was able to get it running locally but running the whole suite there's a lot of other problems with R snippets (notably `multipart/form-data`) that I don't have the energy to address in this PR.

For now, here's what running the `headers` fixture looks like. Note that the `x-` headers are being properly sent and returned through the response from https://httpbin.org/headers:

![Screen Shot 2022-05-19 at 10 24 10 AM](https://user-images.githubusercontent.com/33762/169361706-a6fdcb77-5050-4084-9f38-c101e338688a.png)