### PR TITLE
fix: issue where query strings in R wouldn't be properly concatenated

### DIFF
--- a/__tests__/__fixtures__/output/r/httr/query-encoded.r
+++ b/__tests__/__fixtures__/output/r/httr/query-encoded.r
@@ -3,8 +3,8 @@ library(httr)
 url <- "https://httpbin.org/anything"
 
 queryString <- list(
-  startTime = "2019-06-13T19%3A08%3A25.455Z"
-  endTime = "2015-09-15T14%3A00%3A12-04%3A00",
+  startTime = "2019-06-13T19%3A08%3A25.455Z",
+  endTime = "2015-09-15T14%3A00%3A12-04%3A00"
 )
 
 response <- VERB("GET", url, query = queryString, content_type("application/octet-stream"))

--- a/src/targets/r/httr.js
+++ b/src/targets/r/httr.js
@@ -23,20 +23,17 @@ module.exports = function (source) {
 
   // Construct query string
   const qs = source.queryObj;
-  const queryCount = Object.keys(qs).length;
   // eslint-disable-next-line no-param-reassign
   delete source.queryObj.key;
 
-  if (source.queryString.length === 1) {
+  const queryCount = Object.keys(qs).length;
+  if (queryCount === 1) {
     code.push('queryString <- list(%s = "%s")', Object.keys(qs), Object.values(qs).toString()).blank();
-  } else if (source.queryString.length > 1) {
-    let count = 1;
-
+  } else if (queryCount > 1) {
     code.push('queryString <- list(');
 
-    Object.keys(qs).forEach(query => {
-      // eslint-disable-next-line no-plusplus
-      if (count++ !== queryCount - 1) {
+    Object.keys(qs).forEach((query, i) => {
+      if (i !== queryCount - 1) {
         code.push('  %s = "%s",', query, qs[query].toString());
       } else {
         code.push('  %s = "%s"', query, qs[query].toString());


### PR DESCRIPTION
| 🚥 Fix RM-4465 |
| :-- |

## 🧰 Changes

A user reported this issue to us on our docs where query strings for R wouldn't be properly concatenated with a comma:

```r
library(httr)

url <- "https://dash.readme.com/api/v1/categories"

queryString <- list(
  perPage = "10"    # this is missing a comma
  page = "1",       # this shouldn't have a comma
)

response <- VERB("GET", url, add_headers('Authorization' = 'Basic REDACTED'), query = queryString, content_type("application/octet-stream"))

content(response, "text")
```

Digging into it, because the `httr` target was calculating the total number of query strings before removing the `key` the count would always be off for a query string of two parameters.

Reason the existing `query` fixture tests didn't have this problem was because its query string evaluates to `{ foo: [ 'bar', 'baz' ], baz: 'abc' }`, but with a total of `3` prior to deleting `queryObj.key`.  Because 3 is greater than the number of entries it'd *actually* run through, it wouldn't ever add a comma on the last entry because it would stop running at the 2nd mark.

Super weird bug! 