### PR TITLE
fix: adding HAR validation exceptions for when `postData` is an empty object

### DIFF
--- a/src/fixtures/requests/postdata-malformed.js
+++ b/src/fixtures/requests/postdata-malformed.js
@@ -1,0 +1,56 @@
+module.exports = {
+  log: {
+    version: '1.2',
+    creator: {
+      name: 'HTTPSnippet',
+      version: '1.0.0',
+    },
+    entries: [
+      {
+        request: {
+          method: 'POST',
+          url: 'https://httpbin.org/anything',
+          headers: [
+            {
+              name: 'content-type',
+              value: 'application/json',
+            },
+          ],
+          postData: {
+            // Per the HAR spec `postData` should always have `mimeType` but this fixture is
+            // testing when that isn't the case.
+          },
+        },
+        response: {
+          status: 200,
+          statusText: 'OK',
+          httpVersion: 'HTTP/1.1',
+          headers: [
+            {
+              name: 'Content-Type',
+              value: 'application/json',
+            },
+          ],
+          content: {
+            size: -1,
+            mimeType: 'application/json',
+            text: JSON.stringify({
+              args: {},
+              data: '',
+              files: {},
+              form: {},
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              json: null,
+              method: 'POST',
+              url: 'https://httpbin.org/anything',
+            }),
+          },
+          headersSize: -1,
+          bodySize: -1,
+        },
+      },
+    ],
+  },
+};

--- a/src/helpers/har-validator.ts
+++ b/src/helpers/har-validator.ts
@@ -27,9 +27,25 @@ export const validateHarRequest = (request: any): request is Request => {
   if (!validate) {
     throw new Error('failed to find HAR request schema');
   }
+
   const valid = validate(request);
   if (!valid && validate.errors) {
+    if (validate.errors.length === 1) {
+      // While not ideal, or compliant with the HAR spec, if we have an empty `postData` object in
+      // our HAR and no other errors we should let this through because it's fine and our client
+      // targets are able to handle it okay.
+      const error = validate.errors[0];
+      if (
+        error.dataPath === '.postData' &&
+        error.message === "should have required property 'mimeType'" &&
+        JSON.stringify(request.postData) === '{}'
+      ) {
+        return true;
+      }
+    }
+
     throw new HARError(validate.errors);
   }
+
   return true;
 };

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -232,9 +232,17 @@ availableTargets()
               // check target agnostic we need to parse and re-stringify our expectations so that
               // this test can universally match them all.
               if (expected.headers?.['Content-Type']?.includes('application/json')) {
-                expect(JSON.stringify(JSON.parse(response.data))).toStrictEqual(
-                  JSON.stringify(JSON.parse(expected.data))
-                );
+                // In our postdata-malformed fixture we're sending a POST payload without any
+                // content so what HTTPBin sends back to us is a `json: null` and `data: ''`, which
+                // we need to specially assert here as running `JSON.parse()` on an empty string
+                // will throw an exception.
+                if (fixture === 'postdata-malformed' && response.data === '') {
+                  expect(expected.data).toBe('');
+                } else {
+                  expect(JSON.stringify(JSON.parse(response.data))).toStrictEqual(
+                    JSON.stringify(JSON.parse(expected.data))
+                  );
+                }
               } else {
                 expect(response.data).toStrictEqual(expected.data);
               }

--- a/src/targets/c/libcurl/fixtures/postdata-malformed.c
+++ b/src/targets/c/libcurl/fixtures/postdata-malformed.c
@@ -1,0 +1,10 @@
+CURL *hnd = curl_easy_init();
+
+curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
+curl_easy_setopt(hnd, CURLOPT_URL, "https://httpbin.org/anything");
+
+struct curl_slist *headers = NULL;
+headers = curl_slist_append(headers, "content-type: application/json");
+curl_easy_setopt(hnd, CURLOPT_HTTPHEADER, headers);
+
+CURLcode ret = curl_easy_perform(hnd);

--- a/src/targets/clojure/clj_http/fixtures/postdata-malformed.clj
+++ b/src/targets/clojure/clj_http/fixtures/postdata-malformed.clj
@@ -1,0 +1,3 @@
+(require '[clj-http.client :as client])
+
+(client/post "https://httpbin.org/anything" {:headers {:content-type "application/json"}})

--- a/src/targets/csharp/httpclient/fixtures/postdata-malformed.cs
+++ b/src/targets/csharp/httpclient/fixtures/postdata-malformed.cs
@@ -1,0 +1,13 @@
+using System.Net.Http.Headers;
+var client = new HttpClient();
+var request = new HttpRequestMessage
+{
+    Method = HttpMethod.Post,
+    RequestUri = new Uri("https://httpbin.org/anything"),
+};
+using (var response = await client.SendAsync(request))
+{
+    response.EnsureSuccessStatusCode();
+    var body = await response.Content.ReadAsStringAsync();
+    Console.WriteLine(body);
+}

--- a/src/targets/csharp/restsharp/fixtures/postdata-malformed.cs
+++ b/src/targets/csharp/restsharp/fixtures/postdata-malformed.cs
@@ -1,0 +1,4 @@
+var client = new RestClient("https://httpbin.org/anything");
+var request = new RestRequest(Method.POST);
+request.AddHeader("content-type", "application/json");
+IRestResponse response = client.Execute(request);

--- a/src/targets/go/native/fixtures/postdata-malformed.go
+++ b/src/targets/go/native/fixtures/postdata-malformed.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"io/ioutil"
+)
+
+func main() {
+
+	url := "https://httpbin.org/anything"
+
+	req, _ := http.NewRequest("POST", url, nil)
+
+	req.Header.Add("content-type", "application/json")
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	fmt.Println(res)
+	fmt.Println(string(body))
+
+}

--- a/src/targets/http/http1.1/fixtures/postdata-malformed
+++ b/src/targets/http/http1.1/fixtures/postdata-malformed
@@ -1,0 +1,4 @@
+POST /anything HTTP/1.1
+Content-Type: application/json
+Host: httpbin.org
+

--- a/src/targets/java/asynchttp/fixtures/postdata-malformed.java
+++ b/src/targets/java/asynchttp/fixtures/postdata-malformed.java
@@ -1,0 +1,9 @@
+AsyncHttpClient client = new DefaultAsyncHttpClient();
+client.prepare("POST", "https://httpbin.org/anything")
+  .setHeader("content-type", "application/json")
+  .execute()
+  .toCompletableFuture()
+  .thenAccept(System.out::println)
+  .join();
+
+client.close();

--- a/src/targets/java/nethttp/fixtures/postdata-malformed.java
+++ b/src/targets/java/nethttp/fixtures/postdata-malformed.java
@@ -1,0 +1,7 @@
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("https://httpbin.org/anything"))
+    .header("content-type", "application/json")
+    .method("POST", HttpRequest.BodyPublishers.noBody())
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+System.out.println(response.body());

--- a/src/targets/java/okhttp/fixtures/postdata-malformed.java
+++ b/src/targets/java/okhttp/fixtures/postdata-malformed.java
@@ -1,0 +1,9 @@
+OkHttpClient client = new OkHttpClient();
+
+Request request = new Request.Builder()
+  .url("https://httpbin.org/anything")
+  .post(null)
+  .addHeader("content-type", "application/json")
+  .build();
+
+Response response = client.newCall(request).execute();

--- a/src/targets/java/unirest/fixtures/postdata-malformed.java
+++ b/src/targets/java/unirest/fixtures/postdata-malformed.java
@@ -1,0 +1,3 @@
+HttpResponse<String> response = Unirest.post("https://httpbin.org/anything")
+  .header("content-type", "application/json")
+  .asString();

--- a/src/targets/javascript/axios/fixtures/postdata-malformed.js
+++ b/src/targets/javascript/axios/fixtures/postdata-malformed.js
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+const options = {
+  method: 'POST',
+  url: 'https://httpbin.org/anything',
+  headers: {'content-type': 'application/json'}
+};
+
+axios
+  .request(options)
+  .then(function (response) {
+    console.log(response.data);
+  })
+  .catch(function (error) {
+    console.error(error);
+  });

--- a/src/targets/javascript/fetch/fixtures/postdata-malformed.js
+++ b/src/targets/javascript/fetch/fixtures/postdata-malformed.js
@@ -1,0 +1,6 @@
+const options = {method: 'POST', headers: {'content-type': 'application/json'}};
+
+fetch('https://httpbin.org/anything', options)
+  .then(response => response.json())
+  .then(response => console.log(response))
+  .catch(err => console.error(err));

--- a/src/targets/javascript/jquery/fixtures/postdata-malformed.js
+++ b/src/targets/javascript/jquery/fixtures/postdata-malformed.js
@@ -1,0 +1,13 @@
+const settings = {
+  async: true,
+  crossDomain: true,
+  url: 'https://httpbin.org/anything',
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json'
+  }
+};
+
+$.ajax(settings).done(function (response) {
+  console.log(response);
+});

--- a/src/targets/javascript/xhr/fixtures/postdata-malformed.js
+++ b/src/targets/javascript/xhr/fixtures/postdata-malformed.js
@@ -1,0 +1,15 @@
+const data = null;
+
+const xhr = new XMLHttpRequest();
+xhr.withCredentials = true;
+
+xhr.addEventListener('readystatechange', function () {
+  if (this.readyState === this.DONE) {
+    console.log(this.responseText);
+  }
+});
+
+xhr.open('POST', 'https://httpbin.org/anything');
+xhr.setRequestHeader('content-type', 'application/json');
+
+xhr.send(data);

--- a/src/targets/kotlin/okhttp/fixtures/postdata-malformed.kt
+++ b/src/targets/kotlin/okhttp/fixtures/postdata-malformed.kt
@@ -1,0 +1,9 @@
+val client = OkHttpClient()
+
+val request = Request.Builder()
+  .url("https://httpbin.org/anything")
+  .post(null)
+  .addHeader("content-type", "application/json")
+  .build()
+
+val response = client.newCall(request).execute()

--- a/src/targets/node/axios/fixtures/postdata-malformed.js
+++ b/src/targets/node/axios/fixtures/postdata-malformed.js
@@ -1,0 +1,16 @@
+const axios = require('axios').default;
+
+const options = {
+  method: 'POST',
+  url: 'https://httpbin.org/anything',
+  headers: {'content-type': 'application/json'}
+};
+
+axios
+  .request(options)
+  .then(function (response) {
+    console.log(response.data);
+  })
+  .catch(function (error) {
+    console.error(error);
+  });

--- a/src/targets/node/fetch/fixtures/postdata-malformed.js
+++ b/src/targets/node/fetch/fixtures/postdata-malformed.js
@@ -1,0 +1,9 @@
+const fetch = require('node-fetch');
+
+const url = 'https://httpbin.org/anything';
+const options = {method: 'POST', headers: {'content-type': 'application/json'}};
+
+fetch(url, options)
+  .then(res => res.json())
+  .then(json => console.log(json))
+  .catch(err => console.error('error:' + err));

--- a/src/targets/node/native/fixtures/postdata-malformed.js
+++ b/src/targets/node/native/fixtures/postdata-malformed.js
@@ -1,0 +1,26 @@
+const http = require('https');
+
+const options = {
+  method: 'POST',
+  hostname: 'httpbin.org',
+  port: null,
+  path: '/anything',
+  headers: {
+    'content-type': 'application/json'
+  }
+};
+
+const req = http.request(options, function (res) {
+  const chunks = [];
+
+  res.on('data', function (chunk) {
+    chunks.push(chunk);
+  });
+
+  res.on('end', function () {
+    const body = Buffer.concat(chunks);
+    console.log(body.toString());
+  });
+});
+
+req.end();

--- a/src/targets/node/request/fixtures/postdata-malformed.js
+++ b/src/targets/node/request/fixtures/postdata-malformed.js
@@ -1,0 +1,13 @@
+const request = require('request');
+
+const options = {
+  method: 'POST',
+  url: 'https://httpbin.org/anything',
+  headers: {'content-type': 'application/json'}
+};
+
+request(options, function (error, response, body) {
+  if (error) throw new Error(error);
+
+  console.log(body);
+});

--- a/src/targets/node/unirest/fixtures/postdata-malformed.js
+++ b/src/targets/node/unirest/fixtures/postdata-malformed.js
@@ -1,0 +1,13 @@
+const unirest = require('unirest');
+
+const req = unirest('POST', 'https://httpbin.org/anything');
+
+req.headers({
+  'content-type': 'application/json'
+});
+
+req.end(function (res) {
+  if (res.error) throw new Error(res.error);
+
+  console.log(res.body);
+});

--- a/src/targets/objc/nsurlsession/fixtures/postdata-malformed.m
+++ b/src/targets/objc/nsurlsession/fixtures/postdata-malformed.m
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+
+NSDictionary *headers = @{ @"content-type": @"application/json" };
+
+NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://httpbin.org/anything"]
+                                                       cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                   timeoutInterval:10.0];
+[request setHTTPMethod:@"POST"];
+[request setAllHTTPHeaderFields:headers];
+
+NSURLSession *session = [NSURLSession sharedSession];
+NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request
+                                            completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                                if (error) {
+                                                    NSLog(@"%@", error);
+                                                } else {
+                                                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *) response;
+                                                    NSLog(@"%@", httpResponse);
+                                                }
+                                            }];
+[dataTask resume];

--- a/src/targets/ocaml/cohttp/fixtures/postdata-malformed.ml
+++ b/src/targets/ocaml/cohttp/fixtures/postdata-malformed.ml
@@ -1,0 +1,10 @@
+open Cohttp_lwt_unix
+open Cohttp
+open Lwt
+
+let uri = Uri.of_string "https://httpbin.org/anything" in
+let headers = Header.add (Header.init ()) "content-type" "application/json" in
+
+Client.call ~headers `POST uri
+>>= fun (res, body_stream) ->
+  (* Do stuff with the result *)

--- a/src/targets/php/curl/fixtures/postdata-malformed.php
+++ b/src/targets/php/curl/fixtures/postdata-malformed.php
@@ -1,0 +1,27 @@
+<?php
+
+$curl = curl_init();
+
+curl_setopt_array($curl, [
+  CURLOPT_URL => "https://httpbin.org/anything",
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_ENCODING => "",
+  CURLOPT_MAXREDIRS => 10,
+  CURLOPT_TIMEOUT => 30,
+  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+  CURLOPT_CUSTOMREQUEST => "POST",
+  CURLOPT_HTTPHEADER => [
+    "content-type: application/json"
+  ],
+]);
+
+$response = curl_exec($curl);
+$err = curl_error($curl);
+
+curl_close($curl);
+
+if ($err) {
+  echo "cURL Error #:" . $err;
+} else {
+  echo $response;
+}

--- a/src/targets/php/guzzle/fixtures/postdata-malformed.php
+++ b/src/targets/php/guzzle/fixtures/postdata-malformed.php
@@ -1,0 +1,12 @@
+<?php
+require_once('vendor/autoload.php');
+
+$client = new \GuzzleHttp\Client();
+
+$response = $client->request('POST', 'https://httpbin.org/anything', [
+  'headers' => [
+    'content-type' => 'application/json',
+  ],
+]);
+
+echo $response->getBody();

--- a/src/targets/php/http1/fixtures/postdata-malformed.php
+++ b/src/targets/php/http1/fixtures/postdata-malformed.php
@@ -1,0 +1,17 @@
+<?php
+
+$request = new HttpRequest();
+$request->setUrl('https://httpbin.org/anything');
+$request->setMethod(HTTP_METH_POST);
+
+$request->setHeaders([
+  'content-type' => 'application/json'
+]);
+
+try {
+  $response = $request->send();
+
+  echo $response->getBody();
+} catch (HttpException $ex) {
+  echo $ex;
+}

--- a/src/targets/php/http2/fixtures/postdata-malformed.php
+++ b/src/targets/php/http2/fixtures/postdata-malformed.php
@@ -1,0 +1,15 @@
+<?php
+
+$client = new http\Client;
+$request = new http\Client\Request;
+
+$request->setRequestUrl('https://httpbin.org/anything');
+$request->setRequestMethod('POST');
+$request->setHeaders([
+  'content-type' => 'application/json'
+]);
+
+$client->enqueue($request)->send();
+$response = $client->getResponse();
+
+echo $response->getBody();

--- a/src/targets/powershell/restmethod/fixtures/postdata-malformed.ps1
+++ b/src/targets/powershell/restmethod/fixtures/postdata-malformed.ps1
@@ -1,0 +1,3 @@
+$headers=@{}
+$headers.Add("content-type", "application/json")
+$response = Invoke-RestMethod -Uri 'https://httpbin.org/anything' -Method POST -Headers $headers

--- a/src/targets/powershell/webrequest/fixtures/postdata-malformed.ps1
+++ b/src/targets/powershell/webrequest/fixtures/postdata-malformed.ps1
@@ -1,0 +1,3 @@
+$headers=@{}
+$headers.Add("content-type", "application/json")
+$response = Invoke-WebRequest -Uri 'https://httpbin.org/anything' -Method POST -Headers $headers

--- a/src/targets/python/requests/fixtures/postdata-malformed.py
+++ b/src/targets/python/requests/fixtures/postdata-malformed.py
@@ -1,0 +1,9 @@
+import requests
+
+url = "https://httpbin.org/anything"
+
+headers = {"content-type": "application/json"}
+
+response = requests.post(url, headers=headers)
+
+print(response.text)

--- a/src/targets/r/httr/fixtures/postdata-malformed.r
+++ b/src/targets/r/httr/fixtures/postdata-malformed.r
@@ -1,0 +1,7 @@
+library(httr)
+
+url <- "https://httpbin.org/anything"
+
+response <- VERB("POST", url, content_type("undefined"))
+
+content(response, "text")

--- a/src/targets/ruby/native/fixtures/postdata-malformed.rb
+++ b/src/targets/ruby/native/fixtures/postdata-malformed.rb
@@ -1,0 +1,14 @@
+require 'uri'
+require 'net/http'
+require 'openssl'
+
+url = URI("https://httpbin.org/anything")
+
+http = Net::HTTP.new(url.host, url.port)
+http.use_ssl = true
+
+request = Net::HTTP::Post.new(url)
+request["content-type"] = 'application/json'
+
+response = http.request(request)
+puts response.read_body

--- a/src/targets/shell/curl/fixtures/postdata-malformed.sh
+++ b/src/targets/shell/curl/fixtures/postdata-malformed.sh
@@ -1,0 +1,3 @@
+curl --request POST \
+  --url https://httpbin.org/anything \
+  --header 'content-type: application/json'

--- a/src/targets/shell/httpie/fixtures/postdata-malformed.sh
+++ b/src/targets/shell/httpie/fixtures/postdata-malformed.sh
@@ -1,0 +1,2 @@
+http POST https://httpbin.org/anything \
+  content-type:application/json

--- a/src/targets/shell/wget/fixtures/postdata-malformed.sh
+++ b/src/targets/shell/wget/fixtures/postdata-malformed.sh
@@ -1,0 +1,5 @@
+wget --quiet \
+  --method POST \
+  --header 'content-type: application/json' \
+  --output-document \
+  - https://httpbin.org/anything

--- a/src/targets/swift/nsurlsession/fixtures/postdata-malformed.swift
+++ b/src/targets/swift/nsurlsession/fixtures/postdata-malformed.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+let headers = ["content-type": "application/json"]
+
+let request = NSMutableURLRequest(url: NSURL(string: "https://httpbin.org/anything")! as URL,
+                                        cachePolicy: .useProtocolCachePolicy,
+                                    timeoutInterval: 10.0)
+request.httpMethod = "POST"
+request.allHTTPHeaderFields = headers
+
+let session = URLSession.shared
+let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
+  if (error != nil) {
+    print(error as Any)
+  } else {
+    let httpResponse = response as? HTTPURLResponse
+    print(httpResponse)
+  }
+})
+
+dataTask.resume()

--- a/src/targets/targets.test.ts
+++ b/src/targets/targets.test.ts
@@ -84,9 +84,15 @@ availableTargets()
             it(`${clientId} request should match fixture for "${fixture}.js"`, () => {
               expect(result).toStrictEqual(expected);
             });
-          } catch (error) {
+          } catch (err) {
+            if (err.constructor.name === 'HARError') {
+              throw err;
+            }
+
             throw new Error(
-              `Missing a test file for ${targetId}:${clientId} for the ${fixture} fixture.\nExpected to find the output fixture: \`/src/targets/${targetId}/${clientId}/fixtures/${fixture}${fixtureExtension}\``
+              `Missing a test file for ${targetId}:${clientId} for the ${fixture} fixture.\nExpected to find the output fixture: \`/src/targets/${targetId}/${clientId}/fixtures/${fixture}${
+                fixtureExtension ?? ''
+              }\``
             );
           }
         });


### PR DESCRIPTION
## 🧰 Changes

In some certain situations in our Metrics API `postData` is sent back as an empty object, missing `mimeType`. When this happens now HTTPSnippet throws a fatal exception because `postData.mimeType` should always be present if `postData` is.

Because every client and target within this library is able to handle when `mimeType` isn't present I'm adding an exclusion into the HAR validation to allow this special case through.

## 🧬 QA & Testing

I've added a new test fixture, `postdata-malformed`, for this case and updated the example snippets that every client + target will generate.

This new fixture is also being automatically run without integration suite across Node (Axios, Fetch, HTTP, Request), PHP (cURL, Guzzle), Python (Requests), and Shell (cURL) so if all tests are passing here then this crash will no longer happen in the real world.