### PR TITLE
fix: surfacing content type info when running `open()` in python

### DIFF
--- a/src/targets/python/requests/client.ts
+++ b/src/targets/python/requests/client.ts
@@ -70,7 +70,7 @@ export const requests: Client<RequestsOptions> = {
             if (p.contentType) {
               files[p.name] = `('${p.fileName}', open('${p.fileName}', 'rb'), '${p.contentType}')`;
             } else {
-              files[p.name] = `open('${p.fileName}', 'rb')`;
+              files[p.name] = `('${p.fileName}', open('${p.fileName}', 'rb'))`;
             }
 
             hasFiles = true;
@@ -103,7 +103,7 @@ export const requests: Client<RequestsOptions> = {
         // The `open()` call must be a literal in the code snippet.
         addPostProcessor(code =>
           code
-            .replace(/"open\('(.+)', 'rb'\)"/g, 'open("$1", "rb")')
+            .replace(/"\('(.+)', open\('(.+)', 'rb'\)\)"/g, '("$1", open("$2", "rb"))')
             .replace(/"\('(.+)', open\('(.+)', 'rb'\), '(.+)'\)"/g, '("$1", open("$2", "rb"), "$3")')
         );
         break;

--- a/src/targets/python/requests/client.ts
+++ b/src/targets/python/requests/client.ts
@@ -67,7 +67,12 @@ export const requests: Client<RequestsOptions> = {
         payload = {};
         postData.params.forEach(p => {
           if (p.fileName) {
-            files[p.name] = `open('${p.fileName}', 'rb')`;
+            if (p.contentType) {
+              files[p.name] = `('${p.fileName}', open('${p.fileName}', 'rb'), '${p.contentType}')`;
+            } else {
+              files[p.name] = `open('${p.fileName}', 'rb')`;
+            }
+
             hasFiles = true;
           } else {
             payload[p.name] = p.value;
@@ -96,7 +101,11 @@ export const requests: Client<RequestsOptions> = {
         }
 
         // The `open()` call must be a literal in the code snippet.
-        addPostProcessor(code => code.replace(/"open\('(.+)', 'rb'\)"/g, 'open("$1", "rb")'));
+        addPostProcessor(code =>
+          code
+            .replace(/"open\('(.+)', 'rb'\)"/g, 'open("$1", "rb")')
+            .replace(/"\('(.+)', open\('(.+)', 'rb'\), '(.+)'\)"/g, '("$1", open("$2", "rb"), "$3")')
+        );
         break;
 
       default: {

--- a/src/targets/python/requests/fixtures/multipart-data.py
+++ b/src/targets/python/requests/fixtures/multipart-data.py
@@ -2,7 +2,7 @@ import requests
 
 url = "https://httpbin.org/anything"
 
-files = {"foo": open("src/fixtures/files/hello.txt", "rb")}
+files = {"foo": ("src/fixtures/files/hello.txt", open("src/fixtures/files/hello.txt", "rb"), "text/plain")}
 payload = {"bar": "Bonjour le monde"}
 
 response = requests.post(url, data=payload, files=files)

--- a/src/targets/python/requests/fixtures/multipart-file.py
+++ b/src/targets/python/requests/fixtures/multipart-file.py
@@ -2,7 +2,7 @@ import requests
 
 url = "https://httpbin.org/anything"
 
-files = {"foo": open("src/fixtures/files/hello.txt", "rb")}
+files = {"foo": ("src/fixtures/files/hello.txt", open("src/fixtures/files/hello.txt", "rb"), "text/plain")}
 
 response = requests.post(url, files=files)
 


### PR DESCRIPTION
| 🚥 Fix RM-5624 |
| :-- |

## 🧰 Changes

This updates the Python snippets to do load files, when we have `contentType` info int the HAR, with `(open("squad.csv", "rb"), "squad.csv", "text/csv")` instead of `open("squad.csv", "rb")`.

## 🧬 QA & Testing

Axios tests are still broken with this, but if Python and the other integration tests are passing then this should be good.