### PR TITLE
Fix default http client

### DIFF
--- a/src/helpers/__snapshots__/utils.test.ts.snap
+++ b/src/helpers/__snapshots__/utils.test.ts.snap
@@ -78,7 +78,7 @@ exports[`availableTargets > returns all available targets 1`] = `
         "title": "HTTP/1.1",
       },
     ],
-    "default": "1.1",
+    "default": "http1.1",
     "key": "http",
     "title": "HTTP",
   },

--- a/src/helpers/utils.test.ts
+++ b/src/helpers/utils.test.ts
@@ -8,13 +8,12 @@ describe('availableTargets', () => {
   });
 
   describe('default value check', () => {
-    it.each(
-      availableTargets().map(target => {
-        return [target.title, target];
-      }),
-    )('should match `default` value with one of the client keys (%s)', (_, target) => {
-      expect(target.clients.some(client => client.key === target.default)).toBe(true);
-    });
+    it.each(availableTargets().map(target => [target.title, target]))(
+      'should match `default` value with one of the client keys (%s)',
+      (_, target) => {
+        expect(target.clients).toContainEqual(expect.objectContaining({ key: target.default }));
+      },
+    );
   });
 });
 

--- a/src/helpers/utils.test.ts
+++ b/src/helpers/utils.test.ts
@@ -6,6 +6,16 @@ describe('availableTargets', () => {
   it('returns all available targets', () => {
     expect(availableTargets()).toMatchSnapshot();
   });
+
+  describe('default value check', () => {
+    it.each(
+      availableTargets().map(target => {
+        return [target.title, target];
+      }),
+    )('should match `default` value with one of the client keys (%s)', (_, target) => {
+      expect(target.clients.some(client => client.key === target.default)).toBe(true);
+    });
+  });
 });
 
 describe('extname', () => {

--- a/src/targets/http/target.ts
+++ b/src/targets/http/target.ts
@@ -6,7 +6,7 @@ export const http: Target = {
   info: {
     key: 'http',
     title: 'HTTP',
-    default: '1.1',
+    default: 'http1.1',
   },
   clientsById: {
     'http1.1': http11,


### PR DESCRIPTION
| 🚥 Resolves N/A|
| :------------------- |

## 🧰 Changes
The `default` for http does not match any client IDs. This will cause issues when trying to generate a code sample using `.convert` and trying to use the `default` as the second param.

## 🧬 QA & Testing
You can run the following typescript code
```TypeScript
import { availableTargets } from "@readme/httpsnippet";

const languageTargets = availableTargets();
const httpLanguageTarget = languageTargets.find(
  (target) => target.key === "http",
); // Can add a ! at the end for type checker
snippet = new HTTPSnippet({
  bodySize = -1,
  cookies: [],
  headers: [],
  headersSize: -1,
  httpVersion: "HTTP/1.1",
  method: "GET",
  queryString: [],
  url: "https://www.example.com/foo",
}).convert(httpLanguageTarget, httpLanguageTarget.default)

```

## Current behavior
```
TypeError: Cannot destructure property 'convert' of 'target.clientsById[(clientId || target.info.default)]' as it is undefined.
    at HTTPSnippet.convert (webpack-internal:///(app-pages-browser)/./node_modules/@readme/httpsnippet/dist/index.mjs:230:15)
```

## Expected Behavior

Should just work
