### PR TITLE
feat: creation of a new interface for combined target + client installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ npm install --save @readme/httpsnippet
 
 ## Usage
 
-### HTTPSnippet(source [, options])
+### HTTPSnippet(input [, options])
 
-#### source
+#### input
 
 _Required_ Type: `object`
 
-Name of [conversion target](https://github.com/Kong/httpsnippet/wiki/Targets)
+The [HAR](http://www.softwareishard.com/blog/har-12-spec/#request) request object to generate a snippet for.
 
 ```ts
 import { HTTPSnippet } from 'httpsnippet';
@@ -128,13 +128,13 @@ HTTPSnippet.addTarget(customLanguageTarget);
 
 ### addTargetClient(target, client)
 
-### Target
+#### Target
 
 _Required_ Type: `string`
 
 Name of [conversion target](https://github.com/Kong/httpsnippet/wiki/Targets)
 
-### Client
+#### Client
 
 _Required_ Type: `object`
 
@@ -144,6 +144,34 @@ Representation of a [conversion target client](https://github.com/Kong/httpsnipp
 import { customClient } from 'httpsnippet-for-my-node-http-client';
 HTTPSnippet.addTargetClient('node', customClient);
 ```
+
+### addClientPlugin(plugin)
+
+#### Plugin
+
+_Required_ Type: `object`
+
+The client plugin to install.
+
+```ts
+addClientPlugin({
+  target: 'node',
+  client: {
+    info: {
+      key: 'custom',
+      title: 'Custom HTTP library',
+      link: 'https://example.com',
+      description: 'A custom HTTP library',
+      extname: '.custom',
+    },
+    convert: () => {
+      return 'This was generated from a custom client.';
+    },
+  },
+});
+```
+
+The above example will create a new `custom` client snippet generator for the `node` target.
 
 ## Documentation
 
@@ -161,6 +189,7 @@ There are some major differences between this library and the [httpsnippet](http
 - The main `HTTPSnippet` export contains an `options` argument for an `harIsAlreadyEncoded` option for disabling [escaping](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) of cookies and query strings in URLs.
   - We added this because all HARs that we interact with already have this data escaped and this option prevents them from being double encoded, thus corrupting the data.
 - Does not support the `insecureSkipVerify` option on `go:native`, `node:native`, `ruby:native`, and `shell:curl` as we don't want snippets generated for our users to bypass SSL certificate verification.
+- Includes a full plugin system, `#addClientPlugin`, for quick installation of a target client.
 - Node
   - `fetch`
     - Body payloads are treated as an object literal and wrapped within `JSON.stringify()`. We do this to keep those targets looking nicer with those kinds of payloads. This also applies to the JS `fetch` target as well.

--- a/src/targets/index.test.ts
+++ b/src/targets/index.test.ts
@@ -1,4 +1,4 @@
-import type { Client, ClientId, Target, TargetId } from './index.js';
+import type { Client, ClientId, ClientPlugin, Target, TargetId } from './index.js';
 import type { HTTPSnippetOptions, Request } from '../index.js';
 
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -10,7 +10,7 @@ import short from '../fixtures/requests/short.cjs';
 import { availableTargets, extname } from '../helpers/utils.js';
 import { HTTPSnippet } from '../index.js';
 
-import { isClient, isTarget, addTarget, addTargetClient, targets } from './index.js';
+import { isClient, isTarget, addTarget, addTargetClient, targets, addClientPlugin } from './index.js';
 
 const expectedBasePath = ['src', 'fixtures', 'requests'];
 
@@ -310,6 +310,38 @@ describe('addTargetClient', () => {
     };
 
     addTargetClient('node', customClient);
+
+    const snippet = new HTTPSnippet(short.log.entries[0].request as Request, {});
+
+    const result = await snippet.convert('node', 'custom');
+
+    expect(result).toBe('This was generated from a custom client.');
+  });
+});
+
+describe('addClientPlugin', () => {
+  afterEach(() => {
+    delete targets.node.clientsById.custom;
+  });
+
+  it('should add a new custom target', async () => {
+    const customPlugin: ClientPlugin = {
+      target: 'node',
+      client: {
+        info: {
+          key: 'custom',
+          title: 'Custom HTTP library',
+          link: 'https://example.com',
+          description: 'A custom HTTP library',
+          extname: '.custom',
+        },
+        convert: () => {
+          return 'This was generated from a custom client.';
+        },
+      },
+    };
+
+    addClientPlugin(customPlugin);
 
     const snippet = new HTTPSnippet(short.log.entries[0].request as Request, {});
 

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -44,6 +44,11 @@ export interface Client<T extends Record<string, any> = Record<string, any>> {
   info: ClientInfo;
 }
 
+export interface ClientPlugin {
+  client: Client;
+  target: TargetId;
+}
+
 export type Extension = `.${string}` | null;
 
 export interface TargetInfo {
@@ -184,6 +189,10 @@ export const isClient = (client: Client): client is Client => {
   }
 
   return true;
+};
+
+export const addClientPlugin = (plugin: ClientPlugin) => {
+  addTargetClient(plugin.target, plugin.client);
 };
 
 export const addTargetClient = (targetId: TargetId, client: Client) => {


### PR DESCRIPTION
## 🧰 Changes

In `@readme/oas-to-snippet` right now the way we're installing `httpsnippet-client-api` is the following:

```js
addTargetClient('node', HTTPSnippetSimpleApiClient);
```

This works normally but because we'd love to have folks create their own client plugins and give us NPM packages we don't want to have to supply a target for these plugins when it's easier if the plugin can define that themselves.

The work I've done here is to create a new `addClientPlugin` hook for installing a one of these target + client combinations and then also a new `ClientPlugin` interface that combines the two so we can enforce that plugins are properly defined:

```ts
interface ClientPlugin {
  client: Client;
  target: TargetId;
}
```

With all this work we'll be able to now execute the folllowing to install `httpsnippet-client-api` (once it's been converted to this new system of course):

```js
addClientPlugin(HTTPSnippetSimpleApiClient);
```