### PR TITLE
feat: client config for documenting installation instructions

### DIFF
--- a/src/helpers/__snapshots__/utils.test.ts.snap
+++ b/src/helpers/__snapshots__/utils.test.ts.snap
@@ -44,6 +44,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Simple REST and HTTP API Client for .NET",
         "extname": ".cs",
+        "installation": "dotnet add package RestSharp",
         "key": "restsharp",
         "link": "http://restsharp.org/",
         "title": "RestSharp",
@@ -129,6 +130,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Promise based HTTP client for the browser and node.js",
         "extname": ".js",
+        "installation": "npm install axios --save",
         "key": "axios",
         "link": "https://github.com/axios/axios",
         "title": "Axios",
@@ -193,6 +195,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Simplified HTTP request client",
         "extname": ".cjs",
+        "installation": "npm install request --save",
         "key": "request",
         "link": "https://github.com/request/request",
         "title": "Request",
@@ -207,6 +210,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Promise based HTTP client for the browser and node.js",
         "extname": ".cjs",
+        "install": "npm install axios --save",
         "key": "axios",
         "link": "https://github.com/axios/axios",
         "title": "Axios",
@@ -214,6 +218,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Simplified HTTP node-fetch client",
         "extname": ".cjs",
+        "installation": "npm install node-fetch@2 --save",
         "key": "fetch",
         "link": "https://github.com/bitinn/node-fetch",
         "title": "Fetch",
@@ -242,6 +247,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Cohttp is a very lightweight HTTP server using Lwt or Async for OCaml",
         "extname": ".ml",
+        "installation": "opam install cohttp-lwt-unix cohttp-async",
         "key": "cohttp",
         "link": "https://github.com/mirage/ocaml-cohttp",
         "title": "CoHTTP",
@@ -264,6 +270,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "PHP with Guzzle",
         "extname": ".php",
+        "installation": "composer require guzzlehttp/guzzle",
         "key": "guzzle",
         "link": "http://docs.guzzlephp.org/en/stable/",
         "title": "Guzzle",
@@ -314,6 +321,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Requests HTTP library",
         "extname": ".py",
+        "installation": "python -m pip install requests",
         "key": "requests",
         "link": "http://docs.python-requests.org/en/latest/api/#requests.request",
         "title": "Requests",
@@ -364,6 +372,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "a CLI, cURL-like tool for humans",
         "extname": ".sh",
+        "installation": "brew install httpie",
         "key": "httpie",
         "link": "http://httpie.org/",
         "title": "HTTPie",

--- a/src/targets/csharp/restsharp/client.ts
+++ b/src/targets/csharp/restsharp/client.ts
@@ -14,6 +14,7 @@ export const restsharp: Client = {
     link: 'http://restsharp.org/',
     description: 'Simple REST and HTTP API Client for .NET',
     extname: '.cs',
+    installation: 'dotnet add package RestSharp',
   },
   convert: ({ method, fullUrl, headersObj, cookies, postData, uriObj }) => {
     const { push, join } = new CodeBuilder();

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -29,6 +29,7 @@ export type ClientId = string;
 export interface ClientInfo {
   description: string;
   extname: Extension;
+  installation?: string;
   key: ClientId;
   link: string;
   title: string;

--- a/src/targets/javascript/axios/client.ts
+++ b/src/targets/javascript/axios/client.ts
@@ -20,6 +20,7 @@ export const axios: Client = {
     link: 'https://github.com/axios/axios',
     description: 'Promise based HTTP client for the browser and node.js',
     extname: '.js',
+    installation: 'npm install axios --save',
   },
   convert: ({ allHeaders, method, url, queryObj, postData }, options) => {
     const opts = {

--- a/src/targets/node/axios/client.ts
+++ b/src/targets/node/axios/client.ts
@@ -20,6 +20,7 @@ export const axios: Client = {
     link: 'https://github.com/axios/axios',
     description: 'Promise based HTTP client for the browser and node.js',
     extname: '.cjs',
+    install: 'npm install axios --save',
   },
   convert: ({ method, fullUrl, allHeaders, postData }, options) => {
     const opts = {

--- a/src/targets/node/fetch/client.ts
+++ b/src/targets/node/fetch/client.ts
@@ -21,6 +21,7 @@ export const fetch: Client = {
     link: 'https://github.com/bitinn/node-fetch',
     description: 'Simplified HTTP node-fetch client',
     extname: '.cjs',
+    installation: 'npm install node-fetch@2 --save',
   },
   convert: ({ method, fullUrl, postData, headersObj, cookies }, options) => {
     const opts = {

--- a/src/targets/node/request/client.ts
+++ b/src/targets/node/request/client.ts
@@ -20,6 +20,7 @@ export const request: Client = {
     link: 'https://github.com/request/request',
     description: 'Simplified HTTP request client',
     extname: '.cjs',
+    installation: 'npm install request --save',
   },
   convert: ({ method, url, fullUrl, postData, headersObj, cookies }, options) => {
     const opts = {

--- a/src/targets/ocaml/cohttp/client.ts
+++ b/src/targets/ocaml/cohttp/client.ts
@@ -19,6 +19,7 @@ export const cohttp: Client = {
     link: 'https://github.com/mirage/ocaml-cohttp',
     description: 'Cohttp is a very lightweight HTTP server using Lwt or Async for OCaml',
     extname: '.ml',
+    installation: 'opam install cohttp-lwt-unix cohttp-async',
   },
   convert: ({ fullUrl, allHeaders, postData, method }, options) => {
     const opts = {

--- a/src/targets/php/guzzle/client.ts
+++ b/src/targets/php/guzzle/client.ts
@@ -28,6 +28,7 @@ export const guzzle: Client<GuzzleOptions> = {
     link: 'http://docs.guzzlephp.org/en/stable/',
     description: 'PHP with Guzzle',
     extname: '.php',
+    installation: 'composer require guzzlehttp/guzzle',
   },
   convert: ({ postData, fullUrl, method, cookies, headersObj }, options) => {
     const opts = {

--- a/src/targets/python/requests/client.ts
+++ b/src/targets/python/requests/client.ts
@@ -27,6 +27,7 @@ export const requests: Client<RequestsOptions> = {
     link: 'http://docs.python-requests.org/en/latest/api/#requests.request',
     description: 'Requests HTTP library',
     extname: '.py',
+    installation: 'python -m pip install requests',
   },
   convert: ({ fullUrl, postData, allHeaders, method }, options) => {
     const opts = {

--- a/src/targets/shell/httpie/client.ts
+++ b/src/targets/shell/httpie/client.ts
@@ -33,6 +33,7 @@ export const httpie: Client<HttpieOptions> = {
     link: 'http://httpie.org/',
     description: 'a CLI, cURL-like tool for humans',
     extname: '.sh',
+    installation: 'brew install httpie',
   },
   convert: ({ allHeaders, postData, queryObj, fullUrl, method, url }, options) => {
     const opts = {


### PR DESCRIPTION
## 🧰 Changes

This create a new optional `installation` property on clients that allows us to document how to install that given client. We have this same work in `@readme/oas-to-snippet`[^1] but because wth https://github.com/readmeio/httpsnippet/pull/206 I'm moving some of this work to be loaded as a plugin in that library it makes more sense for these installation instructions to live as close to the client snippet generation code as possible.

And because this is adding an optional property to the client config I'm not going to treat this as a breaking change.

[^1]: https://github.com/readmeio/oas/blob/main/packages/oas-to-snippet/src/supportedLanguages.ts#L43