### PR TITLE
fix(cURL): short `-d` option handling

### DIFF
--- a/src/targets/shell/curl/client.ts
+++ b/src/targets/shell/curl/client.ts
@@ -139,7 +139,7 @@ export const curl: Client<CurlOptions> = {
             const encoded = encodeURIComponent(param.name);
             const needsEncoding = encoded !== unencoded;
             const name = needsEncoding ? encoded : unencoded;
-            const flag = binary ? '--data-binary' : `--data${needsEncoding ? '-urlencode' : ''}`;
+            const flag = binary ? '--data-binary' : needsEncoding ? '--data-urlencode' : arg('data');
             push(`${flag} ${quote(`${name}=${param.value}`)}`);
           });
         } else {

--- a/src/targets/shell/curl/fixtures/short-options.sh
+++ b/src/targets/shell/curl/fixtures/short-options.sh
@@ -1,1 +1,1 @@
-curl -X POST 'https://httpbin.org/anything?foo=bar&foo=baz&baz=abc&key=value' -H 'accept: application/json' -H 'content-type: application/x-www-form-urlencoded' -b 'foo=bar; bar=baz' --data foo=bar
+curl -X POST 'https://httpbin.org/anything?foo=bar&foo=baz&baz=abc&key=value' -H 'accept: application/json' -H 'content-type: application/x-www-form-urlencoded' -b 'foo=bar; bar=baz' -d foo=bar


### PR DESCRIPTION
One of the code paths was not using the `arg()` helper.
