### PR TITLE
fix(breaking): always return array

### DIFF
--- a/src/fixtures/runCustomFixtures.ts
+++ b/src/fixtures/runCustomFixtures.ts
@@ -31,7 +31,7 @@ export const runCustomFixtures = ({ targetId, clientId, tests }: CustomFixture) 
       }
 
       const snippet = new HTTPSnippet(request, opts);
-      const result = snippet.convert(targetId, clientId, options);
+      const result = snippet.convert(targetId, clientId, options)[0];
       const filePath = path.join(__dirname, '..', 'targets', targetId, clientId, 'fixtures', fixtureFile);
       if (process.env.OVERWRITE_EVERYTHING) {
         writeFileSync(filePath, String(result));

--- a/src/index.ts
+++ b/src/index.ts
@@ -334,6 +334,6 @@ export class HTTPSnippet {
 
     const { convert } = target.clientsById[clientId || target.info.default];
     const results = this.requests.map(request => convert(request, options));
-    return results.length === 1 ? results[0] : results;
+    return results;
   }
 }

--- a/src/targets/index.test.ts
+++ b/src/targets/index.test.ts
@@ -74,8 +74,8 @@ describe('request validation', () => {
               `${fixture}${extname(targetId, clientId)}`,
             );
 
-            let result;
-            let expected;
+            let result: string[] | false;
+            let expected: string;
 
             try {
               const options: HTTPSnippetOptions = {};
@@ -88,7 +88,7 @@ describe('request validation', () => {
               expected = readFileSync(expectedPath).toString();
               const snippet = new HTTPSnippet(request, options);
 
-              result = snippet.convert(targetId, clientId);
+              result = snippet.convert(targetId, clientId)[0];
 
               if (OVERWRITE_EVERYTHING && result) {
                 writeFileSync(expectedPath, String(result));
@@ -313,7 +313,7 @@ describe('addTargetClient', () => {
 
     const snippet = new HTTPSnippet(short.log.entries[0].request as Request, {});
 
-    const result = snippet.convert('node', 'custom');
+    const result = snippet.convert('node', 'custom')[0];
 
     expect(result).toBe('This was generated from a custom client.');
   });
@@ -345,7 +345,7 @@ describe('addClientPlugin', () => {
 
     const snippet = new HTTPSnippet(short.log.entries[0].request as Request, {});
 
-    const result = snippet.convert('node', 'custom');
+    const result = snippet.convert('node', 'custom')[0];
 
     expect(result).toBe('This was generated from a custom client.');
   });


### PR DESCRIPTION
## 🧰 Changes

I had DX concerns about the `string[] | string` setup in the `.convert()` method and talked offline with @erunion and agreed that it should always return a `string[]`, so this PR makes that change. This is a breaking change.

## 🧬 QA & Testing

Is this everything? I saw this line below but I think it's unrelated so I left it, but let me know if I'm wrong about this.

https://github.com/readmeio/httpsnippet/blob/fc92e4000714ec677bbf712fc9537fd616e8ae65/src/targets/index.ts#L41
