### PR TITLE
ci: shuffle a few things around

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - run: npm cit
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
       - run: npm ci
-      - run: npm run build
-      - run: npm test
+      - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -70,11 +70,12 @@
     "attw": "attw --pack --format table-flipped",
     "build": "tsup",
     "clean": "rm -rf dist/",
-    "lint": "eslint . --ext .js,.cjs,.ts",
+    "lint": "npm run lint:js && npm run prettier",
+    "lint:js": "eslint . --ext .js,.cjs,.ts && prettier --check .",
     "prebuild": "npm run clean",
     "prepack": "npm run build",
-    "pretest": "npm run lint && npm run prettier",
-    "prettier": "prettier --list-different --write .",
+    "prettier": "prettier --check .",
+    "prettier:write": "prettier --check --write .",
     "test": "vitest run --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
refactors our CI a bit:
- don't use `--write` flag when running prettier in CI
- splits out linting + tests