### PR TITLE
feat: support for making installation string generation dynamic

### DIFF
--- a/src/helpers/__snapshots__/utils.test.ts.snap
+++ b/src/helpers/__snapshots__/utils.test.ts.snap
@@ -44,7 +44,6 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Simple REST and HTTP API Client for .NET",
         "extname": ".cs",
-        "installation": "dotnet add package RestSharp",
         "key": "restsharp",
         "link": "http://restsharp.org/",
         "title": "RestSharp",
@@ -130,7 +129,6 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Promise based HTTP client for the browser and node.js",
         "extname": ".js",
-        "installation": "npm install axios --save",
         "key": "axios",
         "link": "https://github.com/axios/axios",
         "title": "Axios",
@@ -195,7 +193,6 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Promise based HTTP client for the browser and node.js",
         "extname": ".js",
-        "installation": "npm install axios --save",
         "key": "axios",
         "link": "https://github.com/axios/axios",
         "title": "Axios",
@@ -231,7 +228,6 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Cohttp is a very lightweight HTTP server using Lwt or Async for OCaml",
         "extname": ".ml",
-        "installation": "opam install cohttp-lwt-unix cohttp-async",
         "key": "cohttp",
         "link": "https://github.com/mirage/ocaml-cohttp",
         "title": "CoHTTP",
@@ -254,7 +250,6 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "PHP with Guzzle",
         "extname": ".php",
-        "installation": "composer require guzzlehttp/guzzle",
         "key": "guzzle",
         "link": "http://docs.guzzlephp.org/en/stable/",
         "title": "Guzzle",
@@ -305,7 +300,6 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Requests HTTP library",
         "extname": ".py",
-        "installation": "python -m pip install requests",
         "key": "requests",
         "link": "http://docs.python-requests.org/en/latest/api/#requests.request",
         "title": "Requests",
@@ -356,7 +350,6 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "a CLI, cURL-like tool for humans",
         "extname": ".sh",
-        "installation": "brew install httpie",
         "key": "httpie",
         "link": "http://httpie.org/",
         "title": "HTTPie",

--- a/src/helpers/__snapshots__/utils.test.ts.snap
+++ b/src/helpers/__snapshots__/utils.test.ts.snap
@@ -44,6 +44,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Simple REST and HTTP API Client for .NET",
         "extname": ".cs",
+        "installation": [Function],
         "key": "restsharp",
         "link": "http://restsharp.org/",
         "title": "RestSharp",
@@ -129,6 +130,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Promise based HTTP client for the browser and node.js",
         "extname": ".js",
+        "installation": [Function],
         "key": "axios",
         "link": "https://github.com/axios/axios",
         "title": "Axios",
@@ -193,6 +195,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Promise based HTTP client for the browser and node.js",
         "extname": ".js",
+        "installation": [Function],
         "key": "axios",
         "link": "https://github.com/axios/axios",
         "title": "Axios",
@@ -228,6 +231,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Cohttp is a very lightweight HTTP server using Lwt or Async for OCaml",
         "extname": ".ml",
+        "installation": [Function],
         "key": "cohttp",
         "link": "https://github.com/mirage/ocaml-cohttp",
         "title": "CoHTTP",
@@ -250,6 +254,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "PHP with Guzzle",
         "extname": ".php",
+        "installation": [Function],
         "key": "guzzle",
         "link": "http://docs.guzzlephp.org/en/stable/",
         "title": "Guzzle",
@@ -300,6 +305,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "Requests HTTP library",
         "extname": ".py",
+        "installation": [Function],
         "key": "requests",
         "link": "http://docs.python-requests.org/en/latest/api/#requests.request",
         "title": "Requests",
@@ -350,6 +356,7 @@ exports[`availableTargets > returns all available targets 1`] = `
       {
         "description": "a CLI, cURL-like tool for humans",
         "extname": ".sh",
+        "installation": [Function],
         "key": "httpie",
         "link": "http://httpie.org/",
         "title": "HTTPie",

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,11 +348,11 @@ export class HTTPSnippet {
 
     const target = targets[targetId];
     if (!target) {
-      return false;
+      return [false];
     }
 
-    const { installation } = target.clientsById[clientId || target.info.default];
-    const results = this.requests.map(request => (installation ? installation(request, options) : false));
+    const { info } = target.clientsById[clientId || target.info.default];
+    const results = this.requests.map(request => (info?.installation ? info.installation(request, options) : false));
     return results;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,12 +302,12 @@ export class HTTPSnippet {
       ...urlWithParsedQuery,
       query: null,
       search: null,
-    });
+    }); //?
 
     const fullUrl = urlFormat({
       ...urlWithParsedQuery,
       ...uriObj,
-    });
+    }); //?
 
     return {
       ...request,
@@ -318,7 +318,7 @@ export class HTTPSnippet {
     };
   }
 
-  convert(targetId: TargetId, clientId?: ClientId, options?: any): string[] | false {
+  convert(targetId: TargetId, clientId?: ClientId, options?: any) {
     if (!this.initCalled) {
       this.init();
     }
@@ -337,7 +337,7 @@ export class HTTPSnippet {
     return results;
   }
 
-  installation(targetId: TargetId, clientId?: ClientId, options?: any): (string | false)[] | false {
+  installation(targetId: TargetId, clientId?: ClientId, options?: any) {
     if (!this.initCalled) {
       this.init();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -302,12 +302,12 @@ export class HTTPSnippet {
       ...urlWithParsedQuery,
       query: null,
       search: null,
-    }); //?
+    });
 
     const fullUrl = urlFormat({
       ...urlWithParsedQuery,
       ...uriObj,
-    }); //?
+    });
 
     return {
       ...request,
@@ -318,7 +318,7 @@ export class HTTPSnippet {
     };
   }
 
-  convert(targetId: TargetId, clientId?: ClientId, options?: any) {
+  convert(targetId: TargetId, clientId?: ClientId, options?: any): string[] | false {
     if (!this.initCalled) {
       this.init();
     }
@@ -334,6 +334,25 @@ export class HTTPSnippet {
 
     const { convert } = target.clientsById[clientId || target.info.default];
     const results = this.requests.map(request => convert(request, options));
+    return results;
+  }
+
+  installation(targetId: TargetId, clientId?: ClientId, options?: any): (string | false)[] | false {
+    if (!this.initCalled) {
+      this.init();
+    }
+
+    if (!options && clientId) {
+      options = clientId;
+    }
+
+    const target = targets[targetId];
+    if (!target) {
+      return false;
+    }
+
+    const { installation } = target.clientsById[clientId || target.info.default];
+    const results = this.requests.map(request => (installation ? installation(request, options) : false));
     return results;
   }
 }

--- a/src/targets/csharp/restsharp/client.ts
+++ b/src/targets/csharp/restsharp/client.ts
@@ -14,8 +14,8 @@ export const restsharp: Client = {
     link: 'http://restsharp.org/',
     description: 'Simple REST and HTTP API Client for .NET',
     extname: '.cs',
+    installation: () => 'dotnet add package RestSharp',
   },
-  installation: () => 'dotnet add package RestSharp',
   convert: ({ method, fullUrl, headersObj, cookies, postData, uriObj }) => {
     const { push, join } = new CodeBuilder();
     const isSupportedMethod = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].includes(

--- a/src/targets/csharp/restsharp/client.ts
+++ b/src/targets/csharp/restsharp/client.ts
@@ -14,8 +14,8 @@ export const restsharp: Client = {
     link: 'http://restsharp.org/',
     description: 'Simple REST and HTTP API Client for .NET',
     extname: '.cs',
-    installation: 'dotnet add package RestSharp',
   },
+  installation: () => 'dotnet add package RestSharp',
   convert: ({ method, fullUrl, headersObj, cookies, postData, uriObj }) => {
     const { push, join } = new CodeBuilder();
     const isSupportedMethod = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'].includes(

--- a/src/targets/index.test.ts
+++ b/src/targets/index.test.ts
@@ -303,6 +303,9 @@ describe('addTargetClient', () => {
         link: 'https://example.com',
         description: 'A custom HTTP library',
         extname: '.custom',
+        installation: request => {
+          return `brew install ${request.fullUrl}`;
+        },
       },
       convert: () => {
         return 'This was generated from a custom client.';
@@ -314,8 +317,10 @@ describe('addTargetClient', () => {
     const snippet = new HTTPSnippet(short.log.entries[0].request as Request, {});
 
     const result = snippet.convert('node', 'custom')[0];
-
     expect(result).toBe('This was generated from a custom client.');
+
+    const install = snippet.installation('node', 'custom')[0];
+    expect(install).toBe('brew install https://httpbin.org/anything');
   });
 });
 

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -29,7 +29,6 @@ export type ClientId = string;
 export interface ClientInfo {
   description: string;
   extname: Extension;
-  installation?: string;
   key: ClientId;
   link: string;
   title: string;
@@ -43,6 +42,12 @@ export type Converter<T extends Record<string, any>> = (
 export interface Client<T extends Record<string, any> = Record<string, any>> {
   convert: Converter<T>;
   info: ClientInfo;
+  /**
+   * Generates a command to install the client.
+   *
+   * @example `npm install axios`
+   */
+  installation?: Converter<T>;
 }
 
 export interface ClientPlugin<T extends Record<string, any> = Record<string, any>> {

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -26,9 +26,15 @@ export type TargetId = keyof typeof targets;
 
 export type ClientId = string;
 
-export interface ClientInfo {
+export interface ClientInfo<T extends Record<string, any> = Record<string, any>> {
   description: string;
   extname: Extension;
+  /**
+   * Retrieve or generate a command to install the client.
+   *
+   * @example `npm install axios`
+   */
+  installation?: Converter<T>;
   key: ClientId;
   link: string;
   title: string;
@@ -41,13 +47,7 @@ export type Converter<T extends Record<string, any>> = (
 
 export interface Client<T extends Record<string, any> = Record<string, any>> {
   convert: Converter<T>;
-  info: ClientInfo;
-  /**
-   * Generates a command to install the client.
-   *
-   * @example `npm install axios`
-   */
-  installation?: Converter<T>;
+  info: ClientInfo<T>;
 }
 
 export interface ClientPlugin<T extends Record<string, any> = Record<string, any>> {

--- a/src/targets/javascript/axios/client.ts
+++ b/src/targets/javascript/axios/client.ts
@@ -20,8 +20,8 @@ export const axios: Client = {
     link: 'https://github.com/axios/axios',
     description: 'Promise based HTTP client for the browser and node.js',
     extname: '.js',
+    installation: () => 'npm install axios --save',
   },
-  installation: () => 'npm install axios --save',
   convert: ({ allHeaders, method, url, queryObj, postData }, options) => {
     const opts = {
       indent: '  ',

--- a/src/targets/javascript/axios/client.ts
+++ b/src/targets/javascript/axios/client.ts
@@ -20,8 +20,8 @@ export const axios: Client = {
     link: 'https://github.com/axios/axios',
     description: 'Promise based HTTP client for the browser and node.js',
     extname: '.js',
-    installation: 'npm install axios --save',
   },
+  installation: () => 'npm install axios --save',
   convert: ({ allHeaders, method, url, queryObj, postData }, options) => {
     const opts = {
       indent: '  ',

--- a/src/targets/node/axios/client.ts
+++ b/src/targets/node/axios/client.ts
@@ -20,8 +20,8 @@ export const axios: Client = {
     link: 'https://github.com/axios/axios',
     description: 'Promise based HTTP client for the browser and node.js',
     extname: '.js',
-    installation: 'npm install axios --save',
   },
+  installation: () => 'npm install axios --save',
   convert: ({ method, fullUrl, allHeaders, postData }, options) => {
     const opts = {
       indent: '  ',

--- a/src/targets/node/axios/client.ts
+++ b/src/targets/node/axios/client.ts
@@ -20,8 +20,8 @@ export const axios: Client = {
     link: 'https://github.com/axios/axios',
     description: 'Promise based HTTP client for the browser and node.js',
     extname: '.js',
+    installation: () => 'npm install axios --save',
   },
-  installation: () => 'npm install axios --save',
   convert: ({ method, fullUrl, allHeaders, postData }, options) => {
     const opts = {
       indent: '  ',

--- a/src/targets/ocaml/cohttp/client.ts
+++ b/src/targets/ocaml/cohttp/client.ts
@@ -19,8 +19,8 @@ export const cohttp: Client = {
     link: 'https://github.com/mirage/ocaml-cohttp',
     description: 'Cohttp is a very lightweight HTTP server using Lwt or Async for OCaml',
     extname: '.ml',
-    installation: 'opam install cohttp-lwt-unix cohttp-async',
   },
+  installation: () => 'opam install cohttp-lwt-unix cohttp-async',
   convert: ({ fullUrl, allHeaders, postData, method }, options) => {
     const opts = {
       indent: '  ',

--- a/src/targets/ocaml/cohttp/client.ts
+++ b/src/targets/ocaml/cohttp/client.ts
@@ -19,8 +19,8 @@ export const cohttp: Client = {
     link: 'https://github.com/mirage/ocaml-cohttp',
     description: 'Cohttp is a very lightweight HTTP server using Lwt or Async for OCaml',
     extname: '.ml',
+    installation: () => 'opam install cohttp-lwt-unix cohttp-async',
   },
-  installation: () => 'opam install cohttp-lwt-unix cohttp-async',
   convert: ({ fullUrl, allHeaders, postData, method }, options) => {
     const opts = {
       indent: '  ',

--- a/src/targets/php/guzzle/client.ts
+++ b/src/targets/php/guzzle/client.ts
@@ -28,8 +28,8 @@ export const guzzle: Client<GuzzleOptions> = {
     link: 'http://docs.guzzlephp.org/en/stable/',
     description: 'PHP with Guzzle',
     extname: '.php',
-    installation: 'composer require guzzlehttp/guzzle',
   },
+  installation: () => 'composer require guzzlehttp/guzzle',
   convert: ({ postData, fullUrl, method, cookies, headersObj }, options) => {
     const opts = {
       closingTag: false,

--- a/src/targets/php/guzzle/client.ts
+++ b/src/targets/php/guzzle/client.ts
@@ -28,8 +28,8 @@ export const guzzle: Client<GuzzleOptions> = {
     link: 'http://docs.guzzlephp.org/en/stable/',
     description: 'PHP with Guzzle',
     extname: '.php',
+    installation: () => 'composer require guzzlehttp/guzzle',
   },
-  installation: () => 'composer require guzzlehttp/guzzle',
   convert: ({ postData, fullUrl, method, cookies, headersObj }, options) => {
     const opts = {
       closingTag: false,

--- a/src/targets/python/requests/client.ts
+++ b/src/targets/python/requests/client.ts
@@ -27,8 +27,8 @@ export const requests: Client<RequestsOptions> = {
     link: 'http://docs.python-requests.org/en/latest/api/#requests.request',
     description: 'Requests HTTP library',
     extname: '.py',
+    installation: () => 'python -m pip install requests',
   },
-  installation: () => 'python -m pip install requests',
   convert: ({ fullUrl, postData, allHeaders, method }, options) => {
     const opts = {
       indent: '    ',

--- a/src/targets/python/requests/client.ts
+++ b/src/targets/python/requests/client.ts
@@ -27,8 +27,8 @@ export const requests: Client<RequestsOptions> = {
     link: 'http://docs.python-requests.org/en/latest/api/#requests.request',
     description: 'Requests HTTP library',
     extname: '.py',
-    installation: 'python -m pip install requests',
   },
+  installation: () => 'python -m pip install requests',
   convert: ({ fullUrl, postData, allHeaders, method }, options) => {
     const opts = {
       indent: '    ',

--- a/src/targets/shell/httpie/client.ts
+++ b/src/targets/shell/httpie/client.ts
@@ -33,8 +33,8 @@ export const httpie: Client<HttpieOptions> = {
     link: 'http://httpie.org/',
     description: 'a CLI, cURL-like tool for humans',
     extname: '.sh',
-    installation: 'brew install httpie',
   },
+  installation: () => 'brew install httpie',
   convert: ({ allHeaders, postData, queryObj, fullUrl, method, url }, options) => {
     const opts = {
       body: false,

--- a/src/targets/shell/httpie/client.ts
+++ b/src/targets/shell/httpie/client.ts
@@ -33,8 +33,8 @@ export const httpie: Client<HttpieOptions> = {
     link: 'http://httpie.org/',
     description: 'a CLI, cURL-like tool for humans',
     extname: '.sh',
+    installation: () => 'brew install httpie',
   },
-  installation: () => 'brew install httpie',
   convert: ({ allHeaders, postData, queryObj, fullUrl, method, url }, options) => {
     const opts = {
       body: false,


### PR DESCRIPTION
## 🧰 Changes

We're working on some enhancements for HTTP snippet generation for external partners and need to make plugin installation strings dynamic -- this reworks how `installation` is set up on a client basis to allow for this.
