### PR TITLE
refactor: stricter TS types, tsconfig cleanup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,8 +140,21 @@ export class HTTPSnippet {
   ): Request & {
     allHeaders: Record<string, string[] | string>;
     fullUrl: string;
-    url: any;
-    uriObj: any;
+    url: string;
+    uriObj: {
+      query: ReducedHelperObject;
+      search: string;
+      path: string | null;
+      auth: string | null;
+      hash: string | null;
+      host: string | null;
+      hostname: string | null;
+      href: string;
+      pathname: string | null;
+      protocol: string | null;
+      slashes: boolean | null;
+      port: string | null;
+    };
   } {
     const request: Request = {
       ...harRequest,

--- a/src/targets/php/helpers.ts
+++ b/src/targets/php/helpers.ts
@@ -1,6 +1,6 @@
 import { escapeString } from '../../helpers/escape.js';
 
-export const convertType = (obj: any[] | any, indent?: string, lastIndent?: string): unknown => {
+export const convertType = (obj: any[] | any, indent?: string, lastIndent?: string): 'null' | string => {
   lastIndent = lastIndent || '';
   indent = indent || '';
 
@@ -41,7 +41,7 @@ export const convertType = (obj: any[] | any, indent?: string, lastIndent?: stri
   }
 };
 
-export const supportedMethods: string[] = [
+export const supportedMethods = [
   'ACL',
   'BASELINE_CONTROL',
   'CHECKIN',
@@ -69,4 +69,4 @@ export const supportedMethods: string[] = [
   'UNLOCK',
   'UPDATE',
   'VERSION_CONTROL',
-];
+] as const;

--- a/src/targets/php/http1/client.ts
+++ b/src/targets/php/http1/client.ts
@@ -36,14 +36,14 @@ export const http1: Client<Http1Options> = {
       blank();
     }
 
-    if (!supportedMethods.includes(method.toUpperCase())) {
+    if (!supportedMethods.includes(method.toUpperCase() as (typeof supportedMethods)[number])) {
       push(`HttpRequest::methodRegister('${method}');`);
     }
 
     push('$request = new HttpRequest();');
     push(`$request->setUrl(${convertType(url)});`);
 
-    if (supportedMethods.includes(method.toUpperCase())) {
+    if (supportedMethods.includes(method.toUpperCase() as (typeof supportedMethods)[number])) {
       push(`$request->setMethod(HTTP_METH_${method.toUpperCase()});`);
     } else {
       push(`$request->setMethod(HttpRequest::HTTP_METH_${method.toUpperCase()});`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "downlevelIteration": true,
     "esModuleInterop": true,
     "isolatedDeclarations": true,
     "lib": ["DOM", "ES2020"],
@@ -10,13 +9,12 @@
     "noEmit": true,
     "outDir": "dist",
     "resolveJsonModule": true,
+    "strict": true,
     "target": "ES2020",
-
     // Allows us to not have to typeguard in catches.
     // https://bobbyhadz.com/blog/typescript-object-is-of-type-unknown
     "useUnknownInCatchVariables": false,
-
-    "strict": true
+    "verbatimModuleSyntax": true
   },
   "exclude": ["dist/", "./src/fixtures/", "**/*.test.ts"],
   "include": ["./src/**/*"]


### PR DESCRIPTION
rides the coattails of https://github.com/readmeio/httpsnippet/pull/271 with a few stricter return types and a little `tsconfig.json` cleanup.