### PR TITLE
fix: use browser-compatible url imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@ import type { CodeBuilderOptions } from './helpers/code-builder.js';
 import type { ReducedHelperObject } from './helpers/reducer.js';
 import type { ClientId, TargetId } from './targets/index.js';
 import type { Request as NpmHarRequest, Param, PostDataCommon } from 'har-format';
-import type { UrlWithParsedQuery } from 'node:url';
 import type { Merge } from 'type-fest';
+import type { UrlWithParsedQuery } from 'url';
 
-import { format as urlFormat, parse as urlParse } from 'node:url';
+import { format as urlFormat, parse as urlParse } from 'url';
 
 import { stringify as queryStringify } from 'qs';
 


### PR DESCRIPTION
## 🧰 Changes

Switches the `url` imports back to the bare Node module specifier instead of `node:url`.

The package already relied on consumers polyfilling Node’s `url` module for browser builds. After the move to `tsdown`, the published output started preserving `node:url`, which browser bundlers may not resolve through existing `url` fallbacks.

This keeps the runtime behavior the same while restoring compatibility for browser-bundled consumers like `@readme/oas-to-snippet`.